### PR TITLE
Add support for empty state

### DIFF
--- a/app/styles/hypertable.less
+++ b/app/styles/hypertable.less
@@ -15,3 +15,12 @@
 @import "header";
 @import "inner-table";
 @import "footer";
+
+.hypertable__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 100%;
+  width: 100%;
+}

--- a/app/templates/components/hyper-table.hbs
+++ b/app/templates/components/hyper-table.hbs
@@ -122,7 +122,7 @@
       {{#if (has-block "inverse")}}
         {{yield to="inverse"}}
       {{else}}
-        sdfsdfsdfds
+        No Data
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/hyper-table.hbs
+++ b/app/templates/components/hyper-table.hbs
@@ -116,6 +116,16 @@
       {{/if}}
     {{/each}}
   {{/sortable-group}}
+
+  {{#if (eq _collection.length 0)}}
+    <div class="hypertable__state hypertable__state--empty">
+      {{#if (has-block "inverse")}}
+        {{yield to="inverse"}}
+      {{else}}
+        sdfsdfsdfds
+      {{/if}}
+    </div>
+  {{/if}}
 </div>
 
 {{#if footer}}


### PR DESCRIPTION
Allows for two possibilities:
`inverse block` presence => the inverse block is used as empty state
`inverse block` missing => the default message is displayed