### PR TITLE
Hypertable: click outside don't work

### DIFF
--- a/addon/components/hyper-table.js
+++ b/addon/components/hyper-table.js
@@ -229,12 +229,20 @@ export default Component.extend({
       this.manager.set('availableTableViews', false);
     },
 
+    closeAvailableFields() {
+      this.manager.set('availableFieldsPanel', false);
+    },
+
     openAvailableViews() {
       if(this.manager.tetherOn) {
         this.manager.destroyTetherInstance();
       }
       this.manager.toggleProperty('availableTableViews');
       this.manager.set('availableFieldsPanel', false);
+    },
+
+    closeAvailableViews() {
+      this.manager.set('availableTableViews', false);
     },
 
     scrollToEnd() {

--- a/app/templates/components/hyper-table.hbs
+++ b/app/templates/components/hyper-table.hbs
@@ -27,23 +27,25 @@
       Reset Filters
     </button>
 
-    <button class="margin-right-xx-sm margin-bottom-xxx-sm upf-btn upf-btn--default upf-btn--small views-manager-toggle icon-responsive" {{action "openAvailableViews"}}>
+    <button class="margin-right-xx-sm margin-bottom-xxx-sm upf-btn upf-btn--default upf-btn--small views-manager-toggle icon-responsive"
+      {{action "openAvailableViews" bubbles=false}}>
       <i class="fa fa-eye"></i>
       <span>
         &nbsp; Table Views
       </span>
     </button>
 
-    <button class="margin-bottom-xxx-sm upf-btn upf-btn--primary upf-btn--small fields-manager-toggle icon-responsive" {{action "openAvailableFields"}}>
-      <i class="fa fa-columns"></i> 
+    <button class="margin-bottom-xxx-sm upf-btn upf-btn--primary upf-btn--small fields-manager-toggle icon-responsive"
+      {{action "openAvailableFields" bubbles=false}}>
+      <i class="fa fa-columns"></i>
       <span>
         &nbsp; Manage Fields
       </span>
     </button>
 
-    {{hyper-table/views manager=this.manager}}
+    {{hyper-table/views manager=this.manager closeAvailableViews=(action "closeAvailableViews")}}
 
-    <div class="available-fields-wrapper {{if manager.availableFieldsPanel 'visible' 'invisible'}}">
+    <div class="available-fields-wrapper {{if manager.availableFieldsPanel 'visible' 'invisible'}}" {{on-click-outside (action "closeAvailableFields")}}>
       <div class="available-fields-wrapper__categories">
         <div class="field-category {{if (not _activeFieldCategory) 'field-category--active'}}" {{action "setFieldCategory"}}>
           <div>All Fields</div>

--- a/app/templates/components/hyper-table/views.hbs
+++ b/app/templates/components/hyper-table/views.hbs
@@ -1,4 +1,4 @@
-<div class="table-views-wrapper {{if manager.availableTableViews 'visible' 'invisible'}}">
+<div class="table-views-wrapper {{if manager.availableTableViews 'visible' 'invisible'}}" {{on-click-outside this.closeAvailableViews}}>
   <div class="view-search-container">
     <div class="text-color-default-light">Search</div>
     {{input
@@ -9,7 +9,7 @@
   <div class="views-container">
     {{#if manager.predefinedViews}}
       {{#each manager.predefinedViews as |view|}}
-        {{hyper-table/views/view view=view deleteView=(action "deleteView") 
+        {{hyper-table/views/view view=view deleteView=(action "deleteView")
                                 toggleUpdateViewModal=(action "toggleUpdateViewModal")
                                 selectedView=selectedView
                                 predefined=true
@@ -21,7 +21,7 @@
     {{/if}}
 
     {{#each (if filteredViews.length filteredViews this.manager.views) as |view|}}
-      {{hyper-table/views/view view=view deleteView=(action "toggleDeleteViewModal") 
+      {{hyper-table/views/view view=view deleteView=(action "toggleDeleteViewModal")
                                toggleUpdateViewModal=(action "toggleUpdateViewModal")
                                selectedView=selectedView
                                onSelectView=(action "selectView")}}
@@ -50,7 +50,7 @@
         </p>
       </div>
     </div>
-    
+
     <div class="modal-footer">
       <button class="upf-btn upf-btn--primary upf-btn--small add-view-btn margin-bottom-xxx-sm" {{action "addView"}}>
         Save View
@@ -73,7 +73,7 @@
         </p>
       </div>
     </div>
-    
+
     <div class="modal-footer btn-group center-block">
       <button class="upf-btn upf-btn--primary upf-btn--small add-view-btn margin-bottom-xxx-sm" {{action "updateView"}}>
         Update


### PR DESCRIPTION
### What does this PR do?

Clicking outside actual rows doesn't trigger the focus out triggering dropdown closing.

To fix that, modifier `{{on-click-outside}}` is used

Related to : https://github.com/upfluence/backlog/issues/266

### What are the observable changes?
Closing work

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
