### PR TITLE
Add filter data control name to filters menus

### DIFF
--- a/addon/mixins/filters-renderer.js
+++ b/addon/mixins/filters-renderer.js
@@ -1,7 +1,12 @@
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   classNames: ['available-filters'],
+
+  _controlNamePrefix: computed('column.key', function() {
+    return `table_column_filter_sort_${this.column.key}`;
+  }),
 
   actions: {
     reset() {

--- a/app/templates/components/hyper-table/column.hbs
+++ b/app/templates/components/hyper-table/column.hbs
@@ -32,7 +32,7 @@
     {{/if}}
   </div>
 
-  <div class="icon-commands">
+  <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" column.key}}>
     {{#if _supportsOrderingOrFiltering}}
       <i data-toggle="tooltip" data-title='Filters' data-placement="bottom" class="fa fa-filter" {{action "toggleFiltersPanel"}}></i>
     {{/if}}

--- a/app/templates/components/hyper-table/facetting.hbs
+++ b/app/templates/components/hyper-table/facetting.hbs
@@ -7,7 +7,7 @@
   {{/each}}
 {{else}}
   {{#each facets as |facet|}}
-    <div class="hypertable__facetting-item">
+    <div class="hypertable__facetting-item" data-control-name={{concat "table_column_filter_sort_facet_" facet.identifier "_toggle"}}>
       <div class="item">
         {{upf-checkbox
           value=facet.applied size="sm" onValueChange=(action "toggleAppliedFacet" facet)}}

--- a/app/templates/components/hyper-table/filters-renderers/date.hbs
+++ b/app/templates/components/hyper-table/filters-renderers/date.hbs
@@ -1,7 +1,7 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Order By</label>
-    <div class="btn-group upf-radio-group">
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_order_by_radiogroup"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value currentValue=column.orderBy label=label
@@ -15,7 +15,7 @@
   {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Filter</label>
 
-    <div class="btn-group upf-radio-group">
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_filter_by_radiogroup"}}>
       {{#each-in filteringOptions as |label value|}}
         {{radio-button
           value=value currentValue=filterOption label=label
@@ -23,7 +23,7 @@
       {{/each-in}}
     </div>
 
-    <div class="filters">
+    <div class="filters" data-control-name={{concat _controlNamePrefix "_date_range_inputs"}}>
       {{#if (eq filterOption "fixed")}}
         <label>Date Range</label>
         {{ember-flatpickr

--- a/app/templates/components/hyper-table/filters-renderers/money.hbs
+++ b/app/templates/components/hyper-table/filters-renderers/money.hbs
@@ -1,7 +1,7 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Order By</label>
-    <div class="btn-group upf-radio-group">
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_order_by_radio"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value currentValue=column.orderBy label=label
@@ -14,7 +14,9 @@
 {{#if column.filterable}}
   {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Display</label>
-    <div class="btn-group upf-radio-group upf-radio-group--block">
+    <div
+      class="btn-group upf-radio-group upf-radio-group--block"
+      data-control-name={{concat _controlNamePrefix "_filter_by_radio"}}>
       {{#each-in existenceFilters as |label value|}}
         {{radio-button
           value=value currentValue=currentExistenceFilter label=label
@@ -23,7 +25,7 @@
     </div>
   {{/input-wrapper}}
 
-  <div class="row">
+  <div class="row" data-control-name={{concat _controlNamePrefix "_range_inputs"}}>
     {{#input-wrapper classNames="col-xs-6"}}
       <label>From</label>
       {{input

--- a/app/templates/components/hyper-table/filters-renderers/numeric.hbs
+++ b/app/templates/components/hyper-table/filters-renderers/numeric.hbs
@@ -1,7 +1,7 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Order By</label>
-    <div class="btn-group upf-radio-group">
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_order_by_radiogroup"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value currentValue=column.orderBy label=label
@@ -14,7 +14,8 @@
 {{#if column.filterable}}
   {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Display</label>
-    <div class="btn-group upf-radio-group upf-radio-group--block">
+    <div class="btn-group upf-radio-group upf-radio-group--block"
+         data-control-name={{concat _controlNamePrefix "_display_radiogroup"}}>
       {{#each-in existenceFilters as |label value|}}
         {{radio-button
           value=value currentValue=currentExistenceFilter label=label
@@ -23,7 +24,7 @@
     </div>
   {{/input-wrapper}}
 
-  <div class="row margin-top-xx-sm">
+  <div class="row margin-top-xx-sm" data-control-name={{concat _controlNamePrefix "_range_radiogroup"}}>
     {{#input-wrapper classNames="col-xs-6"}}
       <label>From</label>
       {{input

--- a/app/templates/components/hyper-table/filters-renderers/text.hbs
+++ b/app/templates/components/hyper-table/filters-renderers/text.hbs
@@ -1,7 +1,7 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Sort</label>
-    <div class="btn-group upf-radio-group">
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_sort_radiogroup"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value currentValue=column.orderBy label=label
@@ -14,7 +14,9 @@
 {{#if column.filterable}}
   {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Display</label>
-    <div class="btn-group upf-radio-group upf-radio-group--block">
+    <div
+      class="btn-group upf-radio-group upf-radio-group--block"
+      data-control-name={{concat _controlNamePrefix "_display_radiogroup"}}>
       {{#each-in existenceFilters as |label value|}}
         {{radio-button
           value=value currentValue=currentExistenceFilter label=label
@@ -26,9 +28,10 @@
   {{#input-wrapper}}
     <label>Search</label>
     <div>
-      {{input
-        type="text" placeholder="Search..." value=_searchQuery
-        class="form-control upf-input upf-input--textarea"}}
+      <Input
+        type="text" placeholder="Search..." @value={{_searchQuery}}
+        data-control-name={{concat _controlNamePrefix "_search_input"}}
+        class="form-control upf-input upf-input--textarea"/>
     </div>
   {{/input-wrapper}}
 


### PR DESCRIPTION
### What does this PR do?

This PR adds `data-control-name` entries to filters menus.

Related to: https://github.com/upfluence/backlog/issues/657