### PR TITLE
Safely navigate to collection's length

### DIFF
--- a/addon/components/hyper-table.js
+++ b/addon/components/hyper-table.js
@@ -101,7 +101,7 @@ export default Component.extend({
 
         this.set(
           '_displayInfinityLoader',
-          _hasInfinity && !_loadingSmthn && this._collection.length > 0
+          _hasInfinity && !_loadingSmthn && (this._collection || []).length > 0
         );
       }, 3000)
     }


### PR DESCRIPTION
### What does this PR do?

Fixes collection.length triggered too early before the collection is ready.

Related to : https://sentry.io/organizations/upfluence/issues/2450648452/?project=5550971&query=is%3Aunresolved

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
