### PR TITLE
Fix click-outside being applied too aggressively 

### DIFF
--- a/addon/mixins/filters-renderer.js
+++ b/addon/mixins/filters-renderer.js
@@ -2,8 +2,6 @@ import Mixin from '@ember/object/mixin';
 import { computed } from '@ember/object';
 
 export default Mixin.create({
-  classNames: ['available-filters'],
-
   _controlNamePrefix: computed('column.key', function() {
     return `table_column_filter_sort_${this.column.key}`;
   }),

--- a/app/templates/components/hyper-table/column.hbs
+++ b/app/templates/components/hyper-table/column.hbs
@@ -40,7 +40,7 @@
   </div>
 
   {{#if (and _supportsOrderingOrFiltering (eq manager.tetherOn column.key))}}
-    <div {{on-click-outside (action "toggleFiltersPanel" bubbles=false)}}>
+    <div class="available-filters" {{on-click-outside (action "toggleFiltersPanel" bubbles=false)}}>
       {{component _filtersRenderingComponent column=column manager=manager}}
     </div>
   {{/if}}


### PR DESCRIPTION
### What does this PR do?

Apply the click-outside handler on the `.available-filters` class so it works on Tether portals.

Related to : https://github.com/upfluence/cs/issues/156

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
