### PR TITLE
Fix numeric filter bounds

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,20 +1,35 @@
+'use strict';
+
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 2017,
-    sourceType: 'module'
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
   },
-  plugins: [
-    'ember'
-  ],
-  extends: [
-    'eslint:recommended',
-    'plugin:ember/recommended'
-  ],
+  plugins: ['ember'],
+  extends: ['eslint:recommended', 'plugin:ember/recommended', 'plugin:prettier/recommended'],
   env: {
     browser: true
   },
   rules: {
+    'no-multiple-empty-lines': [2, { max: 1 }],
+    'ember/no-jquery': 'off',
+    'ember/no-observers': 'off',
+    'ember/no-new-mixins': 'off',
+    'ember/no-mixins': 'off',
+    'ember/no-get': 'off',
+    'ember/avoid-leaking-state-in-ember-objects': 'off',
+    'ember/closure-actions': 'off',
+    'ember/no-global-jquery': 'off',
+    'ember/no-classic-classes': 'off',
+    'ember/no-classic-components': 'off',
+    'ember/require-tagless-components': 'off',
+    'ember/no-actions-hash': 'off',
+    'ember/no-component-lifecycle-hooks': 'off'
   },
   overrides: [
     // node files
@@ -29,24 +44,16 @@ module.exports = {
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],
-      excludedFiles: [
-        'addon/**',
-        'addon-test-support/**',
-        'app/**',
-        'tests/dummy/app/**'
-      ],
+      excludedFiles: ['addon/**', 'addon-test-support/**', 'app/**', 'tests/dummy/app/**'],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,
         node: true
       },
       plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      })
+      rules: {}
     }
   ]
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "printWidth": 120,
+  "proseWrap": "preserve",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "useTabs": false
+}

--- a/addon/components/hyper-table/filters-renderers/numeric.js
+++ b/addon/components/hyper-table/filters-renderers/numeric.js
@@ -1,66 +1,57 @@
-import Component from "@ember/component";
-import { computed, observer } from "@ember/object";
-import { run } from "@ember/runloop";
+import Component from '@ember/component';
+import { computed, observer } from '@ember/object';
+import { run } from '@ember/runloop';
 
-import FiltersRendererMixin from "@upfluence/hypertable/mixins/filters-renderer";
+import FiltersRendererMixin from '@upfluence/hypertable/mixins/filters-renderer';
 
 export default Component.extend(FiltersRendererMixin, {
   lowerBoundFilter: null,
   upperBoundFilter: null,
 
   existenceFilters: {
-    "With Value": "with",
-    "Without Value": "without",
+    'With Value': 'with',
+    'Without Value': 'without'
   },
 
-  orderingOptions: computed("column.orderKey", function () {
+  orderingOptions: computed('column.orderKey', function () {
     return {
-      "0 — 9": `${this.column.orderKey}:asc`,
-      "9 — 0": `${this.column.orderKey}:desc`,
+      '0 — 9': `${this.column.orderKey}:asc`,
+      '9 — 0': `${this.column.orderKey}:desc`
     };
   }),
 
-  currentExistenceFilter: computed(
-    "column.filters.[]",
-    "lowerBoundFilter",
-    "upperBoundFilter",
-    function () {
-      let _existenceFilter = this.column.filters.findBy("key", "existence");
+  currentExistenceFilter: computed('column.filters.[]', 'lowerBoundFilter', 'upperBoundFilter', function () {
+    let _existenceFilter = this.column.filters.findBy('key', 'existence');
 
-      if (_existenceFilter) {
-        return _existenceFilter.value;
-      }
-
-      return this.lowerBoundFilter || this.upperBoundFilter ? "with" : null;
+    if (_existenceFilter) {
+      return _existenceFilter.value;
     }
-  ),
 
-  _: observer("lowerBoundFilter", "upperBoundFilter", function () {
+    return this.lowerBoundFilter || this.upperBoundFilter ? 'with' : null;
+  }),
+
+  _: observer('lowerBoundFilter', 'upperBoundFilter', function () {
     if (this.lowerBoundFilter || this.upperBoundFilter) {
       run.debounce(this, this._addRangeFilter, 1000);
     }
   }),
 
   _addRangeFilter() {
-    this.column.set("filters", [
-      ...(this.lowerBoundFilter
-        ? [{ key: "lower_bound", value: this.lowerBoundFilter }]
-        : []),
-      ...(this.upperBoundFilter
-        ? [{ key: "upper_bound", value: this.upperBoundFilter }]
-        : []),
+    this.column.set('filters', [
+      ...(this.lowerBoundFilter ? [{ key: 'lower_bound', value: this.lowerBoundFilter }] : []),
+      ...(this.upperBoundFilter ? [{ key: 'upper_bound', value: this.upperBoundFilter }] : [])
     ]);
-    this.manager.hooks.onColumnsChange("columns:change");
+    this.manager.hooks.onColumnsChange('columns:change');
   },
 
   didReceiveAttrs() {
     if (this.column) {
-      let lowerBound = this.column.filters.findBy("key", "lower_bound");
-      let upperBound = this.column.filters.findBy("key", "upper_bound");
+      let lowerBound = this.column.filters.findBy('key', 'lower_bound');
+      let upperBound = this.column.filters.findBy('key', 'upper_bound');
 
       this.setProperties({
         lowerBoundFilter: lowerBound?.value,
-        upperBoundFilter: upperBound?.value,
+        upperBoundFilter: upperBound?.value
       });
     }
   },
@@ -71,16 +62,16 @@ export default Component.extend(FiltersRendererMixin, {
     },
 
     existenceFilterChanged(value) {
-      this.set("currentExistenceFilter", value);
+      this.set('currentExistenceFilter', value);
 
-      this.column.set("filters", [{ key: "existence", value }]);
-      this.manager.hooks.onColumnsChange("columns:change");
+      this.column.set('filters', [{ key: 'existence', value }]);
+      this.manager.hooks.onColumnsChange('columns:change');
     },
 
     reset() {
       this._super();
       this.manager.updateOrdering(this.column, null);
       this.setProperties({ lowerBoundFilter: null, upperBoundFilter: null });
-    },
-  },
+    }
+  }
 });


### PR DESCRIPTION
### What does this PR do?
Fixes issue requiring both minimum and maximum values in a numerical filter
<!-- A brief description of the context of this pull request and its purpose. -->

Related to : https://github.com/upfluence/cs/issues/79

### What are the observable changes?
User can enter only a minimum or a maximum when filtering by a number
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
