### PR TITLE
Add support for a passing custom search component

### DIFF
--- a/addon/components/hyper-table.js
+++ b/addon/components/hyper-table.js
@@ -73,7 +73,7 @@ export default Component.extend({
     return typeOf(this.footer);
   }),
 
-  _searchComponentType: computed('searchComponent', function() {
+  _searchComponentType: computed('searchComponent', function () {
     return typeOf(this.searchComponent);
   }),
 

--- a/addon/components/hyper-table.js
+++ b/addon/components/hyper-table.js
@@ -9,6 +9,7 @@ import $ from 'jquery';
 export default Component.extend({
   classNames: ['hypertable-container'],
 
+  searchComponent: null,
   contextualActions: null,
   footer: null,
   bottomReachedOffset: 0,
@@ -70,6 +71,10 @@ export default Component.extend({
 
   _footerType: computed('footer', function () {
     return typeOf(this.footer);
+  }),
+
+  _searchComponentType: computed('searchComponent', function() {
+    return typeOf(this.searchComponent);
   }),
 
   _orderedFilteredClusters: computed('manager.fields', '_availableFieldsKeyword', '_activeFieldCategory', function () {

--- a/app/templates/components/hyper-table.hbs
+++ b/app/templates/components/hyper-table.hbs
@@ -7,13 +7,18 @@
     {{/if}}
 
     {{#if manager.options.features.search}}
-      <Input
-        @type='text'
-        @placeholder={{placeholder}}
-        @value={{_searchQuery}}
-        data-control-name='table_search_input'
-        class='form-control upf-input upf-input--small'
-      />
+      {{#if this.searchComponent}}
+        {{#if (eq this._searchComponentType "string")}}
+          {{component this.searchComponent manager=this.manager}}
+        {{else}}
+          {{searchComponent}}
+        {{/if}}
+      {{else}}
+        <Input
+          @type="text" @placeholder={{placeholder}} @value={{_searchQuery}}
+          data-control-name="table_search_input"
+          class="form-control upf-input upf-input--small" />
+      {{/if}}
     {{/if}}
 
     {{#if (and contextualActions (gt _collection.length 0))}}


### PR DESCRIPTION
### What does this PR do?

Allow a custom search component to be passed in place of the Search Input. Allowed values are:
* string : path to the component
* `component instance` (using the `component` helper) 

<img width="1617" alt="Screenshot 2021-09-07 at 16 08 40" src="https://user-images.githubusercontent.com/4022350/132359135-5d22fcb1-4877-4ec5-b14a-1943a3236d11.png">


### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
