### PR TITLE
Support notification dot on image cell renderer

### DIFF
--- a/addon/components/hyper-table/cell-renderers/image.js
+++ b/addon/components/hyper-table/cell-renderers/image.js
@@ -1,10 +1,8 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { get } from '@ember/object';
 
-export default Component.extend({
-  tagName: '',
-
-  imageURL: computed('item', 'column.key', function () {
-    return this.item.get(this.column.key);
-  })
-});
+export default class ImageCellRenderer extends Component {
+  get imageURL() {
+    return get(this.args.item, this.args.column.key);
+  }
+}

--- a/app/templates/components/hyper-table/cell-renderers/image.hbs
+++ b/app/templates/components/hyper-table/cell-renderers/image.hbs
@@ -1,13 +1,15 @@
 <div>
-  {{upf-image src=imageURL classNames='upf-image--round-36'}}
+  {{upf-image src=this.imageURL classNames="upf-image--round-36"}}
 </div>
 
-{{#if (gt column.labels.length 0)}}
-  <div>
-    {{#each column.labels as |label|}}
-      <span class='margin-left-xx-sm' {{enable-tooltip title=(get item label)}}>
-        {{get item label}}
-      </span>
-    {{/each}}
-  </div>
+{{#if (gt @column.labels.length 0)}}
+  {{#each @column.labels as |label|}}
+    <span class="margin-left-xx-sm text-ellipsis-160" {{enable-tooltip title=(get @item label)}}>
+      {{get @item label}}
+    </span>
+  {{/each}}
+{{/if}}
+
+{{#if @item.hasNotifications}}
+  <span class='upf-notification--inline'></span>
 {{/if}}

--- a/app/templates/components/hyper-table/cell-renderers/image.hbs
+++ b/app/templates/components/hyper-table/cell-renderers/image.hbs
@@ -11,5 +11,5 @@
 {{/if}}
 
 {{#if @item.hasNotifications}}
-  <span class='upf-notification--inline'></span>
+  <span class="upf-notification--inline"></span>
 {{/if}}

--- a/testem.js
+++ b/testem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  test_page: 'tests/index.html?hidepassed',
+  test_page: 'tests/index.html?hidepassed&dockcontainer',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],

--- a/tests/integration/components/hyper-table/cell-renderers/image-test.js
+++ b/tests/integration/components/hyper-table/cell-renderers/image-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | hyper-table/cell-renderers/image', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.item = { imageURL: 'foo.png' };
+    this.column = { key: 'imageURL' };
+
+    await render(hbs`<HyperTable::CellRenderers::Image @item={{this.item}} @column={{this.column}} />`);
+
+    assert
+      .dom('div.upf-image.upf-image--round-36')
+      .hasAttribute('style', 'background-image: url("foo.png"), url("assets/images/no-image.svg");');
+  });
+
+  module('it has labels to show', function () {
+    test('it should display the labels next to the image', async function (assert) {
+      this.item = { imageURL: 'foo.png', name: 'FooBar' };
+      this.column = { key: 'imageURL', labels: ['name'] };
+
+      await render(hbs`<HyperTable::CellRenderers::Image @item={{this.item}} @column={{this.column}} />`);
+
+      assert
+        .dom('div.upf-image.upf-image--round-36')
+        .hasAttribute('style', 'background-image: url("foo.png"), url("assets/images/no-image.svg");');
+
+      assert.dom('span.margin-left-xx-sm.text-ellipsis-160').hasText('FooBar');
+    });
+  });
+
+  module('there is a notification on the item', function () {
+    test('it should display the notification dot next to the labels', async function (assert) {
+      this.item = { imageURL: 'foo.png', name: 'FooBar', hasNotifications: true };
+      this.column = { key: 'imageURL', labels: ['name'] };
+
+      await render(hbs`<HyperTable::CellRenderers::Image @item={{this.item}} @column={{this.column}} />`);
+
+      assert
+        .dom('div.upf-image.upf-image--round-36')
+        .hasAttribute('style', 'background-image: url("foo.png"), url("assets/images/no-image.svg");');
+
+      assert.dom('span.margin-left-xx-sm.text-ellipsis-160').hasText('FooBar');
+      assert.dom('span.upf-notification--inline').exists();
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Add support for notification dot on the image cell renderer.

Related to : https://github.com/upfluence/cs/issues/323

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
