### PR TITLE
Set up right stacking context

### DIFF
--- a/app/styles/header.less
+++ b/app/styles/header.less
@@ -13,6 +13,7 @@
   display: flex;
   justify-content: space-between;
   position: relative;
+  z-index: 2;
 
   button.icon-responsive {
     @media screen and (max-width: 1430px) {
@@ -73,7 +74,7 @@
     margin-left: @spacing-sm;
     padding: 0 @spacing-sm;
 
-    &--no-search-sibling  {
+    &--no-search-sibling {
       border-left: 0;
       margin-left: 0;
       padding: 0;

--- a/app/styles/inner-table.less
+++ b/app/styles/inner-table.less
@@ -7,6 +7,7 @@
   height: 700px;
   overflow: auto;
   position: relative;
+  z-index: 1;
 }
 
 .hypertable__table--empty {


### PR DESCRIPTION
### What does this PR do?

Set up right stacking context. 

Context:
- The `hypertable__sticky-columns` has a `z-index: 20`
- The side-panel has a `z-index: 21`
They share the same stacking context because any other z-index is defined in parent component

Goal:
Set `z-index` to header and table to fix display order

To display a dropdown in contextual action, a stacking need to be defined for hypertable to display section (header, table) in the right order. This is not affect the side-panel display.

Link to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1)

Related to : https://github.com/upfluence/backlog/issues/1093

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
