### PR TITLE
Add reset filters button

### DIFF
--- a/addon-test-support/table-manager.ts
+++ b/addon-test-support/table-manager.ts
@@ -2,6 +2,7 @@ import {
   Column,
   ColumnDefinitionResponse,
   FieldSize,
+  Filter,
   TableColumnsResponse,
   TableManager as ITableManager,
   TableColumnUpsertRequest,
@@ -25,10 +26,10 @@ export const buildColumnDefinition = (key: string, extra?: { [key: string]: any 
   return Object.assign(defaultColumnDefinition, extra || {});
 };
 
-export const buildColumn = (key: string, extra?: { [key: string]: any }): Column => {
+export const buildColumn = (key: string, extra?: { [key: string]: any; filters?: Filter[] }): Column => {
   return {
     definition: buildColumnDefinition(key, extra || {}),
-    filters: []
+    filters: extra?.filters || []
   };
 };
 

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -4,6 +4,9 @@
       Search {{!--to do implemented--}}
     </div>
     <div class="right-side">
+      <OSS::Button class="margin-right-xx-sm" @label={{t "hypertable.features.filtering.reset_all"}}
+                   {{on "click" this.resetFilters}} @loading={{this.loadingResetFilters}}
+                   data-control-name="hypertable_reset_filters_button"/>
       <HyperTableV2::ManageColumns @handler={{@handler}} />
     </div>
   </div>

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
@@ -10,6 +11,7 @@ interface HyperTableV2Args {
 
 export default class HyperTableV2 extends Component<HyperTableV2Args> {
   loadingSkeletons = new Array(3);
+  @tracked loadingResetFilters = false;
 
   constructor(owner: unknown, args: HyperTableV2Args) {
     super(owner, args);
@@ -27,5 +29,13 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   @action
   onBottomReached() {
     this.args.handler.onBottomReached();
+  }
+
+  @action
+  resetFilters() {
+    this.loadingResetFilters = true;
+    this.args.handler.resetColumns(this.args.handler.columns).finally(() => {
+      this.loadingResetFilters = false;
+    });
   }
 }


### PR DESCRIPTION
### What does this PR do?

Add reset filters button

Related to : https://github.com/upfluence/backlog/issues/901

### What are the observable changes?
![Screenshot from 2022-01-19 18-17-46](https://user-images.githubusercontent.com/43567222/150181252-d3f0e4ed-baf6-4107-beb5-b9881f675e49.png)

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
