### PR TITLE
Fixed: Overlapping Columns and unwanted scrollbar

### DIFF
--- a/app/styles/cells.less
+++ b/app/styles/cells.less
@@ -3,7 +3,6 @@
 .hypertable__cell {
   border-bottom: 1px solid lighten(@upf-gray, 15%);
   border-left: 1px solid lighten(@upf-gray, 15%);
-  border-right: 1px solid lighten(@upf-gray, 15%);
   display: flex;
   align-items: center;
   background-color: white;
@@ -11,7 +10,7 @@
   height: @cell-height;
   max-height: @cell-height;
   padding: @spacing-xx-sm;
-  width: calc(100% + 2px);
+  width: 100%;
 
   .tooltip > .tooltip-inner {
     padding: 5px;

--- a/app/styles/columns.less
+++ b/app/styles/columns.less
@@ -24,8 +24,7 @@
 
   &:first-child,
   &:nth-child(2) {
-    .hypertable__cell,
-    header {
+    .hypertable__cell {
       border-left: none;
     }
   }
@@ -49,7 +48,9 @@
 
   header {
     border-left: 1px solid darken(@upf-gray-light, 10%);
-    border-right: 1px solid darken(@upf-gray-light, 10%);
+  }
+  &:nth-child(2) header {
+    border-left: none;
   }
 }
 
@@ -61,7 +62,7 @@
   height: @cell-height;
   max-height: @cell-height;
   padding: @spacing-xx-sm;
-  width: calc(100% + 2px);
+  width: 100%;
 
   background-color: @field-background-color;
   cursor: pointer;
@@ -170,6 +171,14 @@
   width: 40px;
   min-width: 40px;
   flex-grow: 0;
+
+  header {
+    border-right: none;
+  }
+
+  .hypertable__cell {
+    border-right: none;
+  }
 }
 
 .hypertable__column--ordered {

--- a/app/styles/inner-table.less
+++ b/app/styles/inner-table.less
@@ -29,6 +29,19 @@
   header {
     border-right: 1px solid lighten(@upf-gray, 15%);
   }
+
+  header {
+    border-right: 1px solid darken(@upf-gray-light, 10%);
+  }
+
+  &:nth-child(2) header {
+    border-right: none;
+  }
+  &:first-child {
+    header {
+      border-left: none;
+    }
+  }
 }
 
 .hypertable__backdrop {

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -187,6 +187,17 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
 
   module('jumping to the last column', function () {
     test('the button to jump to the last column is displayed if there is overflow', async function (assert: Assert) {
+      sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
+        return Promise.resolve({
+          columns: [
+            buildColumn('foo', { filters: [{ key: 'filter1', value: 'toto' }] }),
+            buildColumn('foo', { filters: [{ key: 'filter2', value: 'foo' }] }),
+            buildColumn('foo', { filters: [{ key: 'filter2', value: 'foo' }] }),
+            buildColumn('foo', { filters: [{ key: 'filter2', value: 'foo' }] }),
+            buildColumn('foo', { filters: [{ key: 'filter2', value: 'foo' }] })
+          ]
+        });
+      });
       await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
 
       assert.dom('.scroll-button-container').exists();


### PR DESCRIPTION
### What does this PR do?

Fixes overlapping columns in the table which used to created an extra 2px width that lead to showing a scrollbar when unwanted.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
