### PR TITLE
Added: Ordering component for filter renderers

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/ordering.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/ordering.hbs
@@ -1,0 +1,10 @@
+<label>{{@label}}</label>
+<div class="btn-group upf-radio-group" ...attributes>
+  {{#each-in this.orderingOptions as |label value|}}
+    <RadioButton @value={{value}}
+                 @currentValue={{this.currentOrderingDirection}}
+                 @label={{label}}
+                 @options={{this.orderingOptions}}
+                 @onCheck={{this.orderingDirectionChanged}} />
+  {{/each-in}}
+</div>

--- a/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
@@ -7,7 +7,7 @@ import { Column, OrderDirection } from '@upfluence/hypertable/core/interfaces';
 interface HyperTableV2FilteringRenderersOrderingArgs {
   handler: TableHandler;
   column: Column;
-  customOrderingOptions: { [key: string]: OrderDirection };
+  orderingOptions: { [key: string]: OrderDirection };
 }
 
 const defaultOrderingDirections: { [key: string]: OrderDirection } = {
@@ -17,7 +17,7 @@ const defaultOrderingDirections: { [key: string]: OrderDirection } = {
 
 export default class HyperTableV2FilteringRenderersOrdering extends Component<HyperTableV2FilteringRenderersOrderingArgs> {
   get orderingOptions() {
-    return this.args?.customOrderingOptions || defaultOrderingDirections;
+    return this.args?.orderingOptions || defaultOrderingDirections;
   }
 
   get currentOrderingDirection(): OrderDirection | undefined {

--- a/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
@@ -1,0 +1,31 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+import TableHandler from '@upfluence/hypertable/core/handler';
+import { Column, OrderDirection } from '@upfluence/hypertable/core/interfaces';
+
+interface HyperTableV2FilteringRenderersOrderingArgs {
+  handler: TableHandler;
+  column: Column;
+  customOrderingOptions: { [key: string]: OrderDirection };
+}
+
+const defaultOrderingDirections: { [key: string]: OrderDirection } = {
+  'A — Z': 'asc',
+  'Z — A': 'desc'
+};
+
+export default class HyperTableV2FilteringRenderersOrdering extends Component<HyperTableV2FilteringRenderersOrderingArgs> {
+  get orderingOptions() {
+    return this.args?.customOrderingOptions || defaultOrderingDirections;
+  }
+
+  get currentOrderingDirection(): OrderDirection | undefined {
+    return this.args.column.order?.direction;
+  }
+
+  @action
+  orderingDirectionChanged(direction: OrderDirection): void {
+    this.args.handler.applyOrder(this.args.column, direction);
+  }
+}

--- a/addon/components/hyper-table-v2/filtering-renderers/date.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.hbs
@@ -3,7 +3,7 @@
   {{#if @column.definition.orderable}}
     <HyperTableV2::FilteringRenderers::Common::Ordering @handler={{@handler}} @column={{@column}}
                                                         @label={{t "hypertable.column.ordering.label"}}
-                                                        @customOrderingOptions={{this.orderingOptions}}
+                                                        @orderingOptions={{this.orderingOptions}}
                                                         data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_order_by_radiogroup"}} />
   {{/if}}
 

--- a/addon/components/hyper-table-v2/filtering-renderers/date.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.hbs
@@ -1,16 +1,10 @@
 <div class="fx-col fx-gap-px-20"
      data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key}}>
   {{#if @column.definition.orderable}}
-    <div class="fx-col">
-      <label>{{t "hypertable.column.ordering.label"}}</label>
-      <div class="btn-group upf-radio-group"
-           data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_order_by_radiogroup"}}>
-        {{#each-in this.orderingOptions as |label value|}}
-          <RadioButton @value={{value}} @currentValue={{this.currentOrderingDirection}} @label={{label}}
-                       @options={{this.orderingOptions}} @onCheck={{this.orderingOptionChanged}} />
-        {{/each-in}}
-      </div>
-    </div>
+    <HyperTableV2::FilteringRenderers::Common::Ordering @handler={{@handler}} @column={{@column}}
+                                                        @label={{t "hypertable.column.ordering.label"}}
+                                                        @customOrderingOptions={{this.orderingOptions}}
+                                                        data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_order_by_radiogroup"}} />
   {{/if}}
 
   {{#if @column.definition.filterable}}

--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
-import { Column, OrderDirection } from '@upfluence/hypertable/core/interfaces';
+import { Column } from '@upfluence/hypertable/core/interfaces';
 import { action } from '@ember/object';
 
 interface HyperTableV2FilteringRenderersDateArgs {
@@ -39,10 +39,6 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
     'Oldest — Newest': 'asc',
     'Newest — Oldest': 'desc'
   };
-
-  get currentOrderingDirection(): OrderDirection | undefined {
-    return this.args.column.order?.direction;
-  }
 
   constructor(owner: unknown, args: HyperTableV2FilteringRenderersDateArgs) {
     super(owner, args);
@@ -80,11 +76,6 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   @action
   closedFlatpickr(): void {
     this._calendarContainer.removeEventListener('click', this._handleFlatpickrClick);
-  }
-
-  @action
-  orderingOptionChanged(direction: OrderDirection): void {
-    this.args.handler.applyOrder(this.args.column, direction);
   }
 
   @action

--- a/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
@@ -3,7 +3,7 @@
   {{#if @column.definition.orderable}}
     <HyperTableV2::FilteringRenderers::Common::Ordering @handler={{@handler}} @column={{@column}}
                                                         @label={{t "hypertable.column.ordering.label"}}
-                                                        @customOrderingOptions={{this.orderingDirections}}
+                                                        @orderingOptions={{this.orderingDirections}}
                                                         data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_ordering"}} />
   {{/if}}
 

--- a/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
@@ -1,19 +1,10 @@
 <div class="fx-col fx-gap-px-20"
      data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key}}>
   {{#if @column.definition.orderable}}
-    <div class="fx-col">
-      <label>{{t "hypertable.column.ordering.label"}}</label>
-      <div class="btn-group upf-radio-group"
-           data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_ordering"}}>
-        {{#each-in this.orderingDirections as |label value|}}
-          <RadioButton @value={{value}}
-                       @currentValue={{this.currentOrderingDirection}}
-                       @label={{label}}
-                       @options={{this.orderingDirections}}
-                       @onCheck={{this.orderingDirectionChanged}} />
-        {{/each-in}}
-      </div>
-    </div>
+    <HyperTableV2::FilteringRenderers::Common::Ordering @handler={{@handler}} @column={{@column}}
+                                                        @label={{t "hypertable.column.ordering.label"}}
+                                                        @customOrderingOptions={{this.orderingDirections}}
+                                                        data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_ordering"}} />
   {{/if}}
 
   {{#if @column.definition.filterable}}

--- a/addon/components/hyper-table-v2/filtering-renderers/numeric.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/numeric.ts
@@ -27,10 +27,6 @@ export default class HyperTableV2FilteringRenderersNumeric extends Component<Hyp
     'Without Value': 'without'
   };
 
-  get currentOrderingDirection(): OrderDirection | undefined {
-    return this.args.column.order?.direction;
-  }
-
   get currentExistenceFilter(): string | null {
     const _existenceFilter = this.args.column.filters.find((filter) => filter.key === 'existence');
 
@@ -51,11 +47,6 @@ export default class HyperTableV2FilteringRenderersNumeric extends Component<Hyp
   @action
   addRangeFilter(): void {
     run.debounce(this, this._addRangeFilter, RANGE_DEBOUNCE_TIME);
-  }
-
-  @action
-  orderingDirectionChanged(direction: OrderDirection): void {
-    this.args.handler.applyOrder(this.args.column, direction);
   }
 
   @action

--- a/addon/components/hyper-table-v2/filtering-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.hbs
@@ -10,20 +10,17 @@
          data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_filters"}}>
       <div class="margin-top-xxx-sm">
         <label>{{t "hypertable.column.filtering.search_term.label"}}</label>
-        <OSS::InputContainer
-                             @value={{this.searchQuery}}
+        <OSS::InputContainer @value={{this.searchQuery}}
                              @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}} />
       </div>
     </div>
   {{/if}}
 
   <div class="margin-top-xx-sm fx-row fx-malign-space-between">
-    <OSS::Button
-                 @skin="destructive" @size="sm" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
+    <OSS::Button @skin="destructive" @size="sm" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
                  data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_remove_column"}} />
 
-    <OSS::Button
-                 @size="sm" @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
+    <OSS::Button @size="sm" @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
                  data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_clear_filters"}} />
   </div>
 </div>

--- a/addon/components/hyper-table-v2/filtering-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.hbs
@@ -1,35 +1,29 @@
 <div data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key}}>
   {{#if @column.definition.orderable}}
-    <label>{{t "hypertable.column.ordering.label"}}</label>
-    <div class="btn-group upf-radio-group" data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_ordering"}}>
-      {{#each-in this.orderingDirections as |label value|}}
-        <RadioButton
-          @value={{value}}
-          @currentValue={{this.currentOrderingDirection}}
-          @label={{label}}
-          @options={{this.orderingDirections}}
-          @onCheck={{this.orderingDirectionChanged}} />
-      {{/each-in}}
-    </div>
+    <HyperTableV2::FilteringRenderers::Common::Ordering @handler={{@handler}} @column={{@column}}
+                                                        @label={{t "hypertable.column.ordering.label"}}
+                                                        data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_ordering"}} />
   {{/if}}
 
   {{#if @column.definition.filterable}}
-    <div class={{if @column.definition.orderable "margin-top-xx-sm"}} data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_filters"}}>
+    <div class={{if @column.definition.orderable "margin-top-xx-sm"}}
+         data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_filters"}}>
       <div class="margin-top-xxx-sm">
         <label>{{t "hypertable.column.filtering.search_term.label"}}</label>
         <OSS::InputContainer
-          @value={{this.searchQuery}} @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}} />
+                             @value={{this.searchQuery}}
+                             @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}} />
       </div>
     </div>
   {{/if}}
 
   <div class="margin-top-xx-sm fx-row fx-malign-space-between">
     <OSS::Button
-      @skin="destructive" @size="sm" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
-      data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_remove_column"}} />
+                 @skin="destructive" @size="sm" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
+                 data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_remove_column"}} />
 
     <OSS::Button
-      @size="sm" @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
-      data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_clear_filters"}} />
+                 @size="sm" @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
+                 data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_clear_filters"}} />
   </div>
 </div>

--- a/addon/components/hyper-table-v2/filtering-renderers/text.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
-import { Column, OrderDirection } from '@upfluence/hypertable/core/interfaces';
+import { Column } from '@upfluence/hypertable/core/interfaces';
 
 interface HyperTableV2FilteringRenderersTextArgs {
   handler: TableHandler;
@@ -13,20 +13,11 @@ interface HyperTableV2FilteringRenderersTextArgs {
 export default class HyperTableV2FilteringRenderersText extends Component<HyperTableV2FilteringRenderersTextArgs> {
   @tracked _searchQuery: string = '';
 
-  orderingDirections: { [key: string]: OrderDirection } = Object.freeze({
-    'A — Z': 'asc',
-    'Z — A': 'desc'
-  });
-
   constructor(owner: unknown, args: HyperTableV2FilteringRenderersTextArgs) {
     super(owner, args);
 
     const searchTerm = this.args.column.filters.find((filter) => filter.key === 'value');
     this._searchQuery = searchTerm?.value || '';
-  }
-
-  get currentOrderingDirection(): OrderDirection | undefined {
-    return this.args.column.order?.direction;
   }
 
   get searchQuery(): string {
@@ -42,11 +33,6 @@ export default class HyperTableV2FilteringRenderersText extends Component<HyperT
         value
       }
     ]);
-  }
-
-  @action
-  orderingDirectionChanged(direction: OrderDirection): void {
-    this.args.handler.applyOrder(this.args.column, direction);
   }
 
   @action

--- a/app/components/hyper-table-v2/filtering-renderers/common/ordering.js
+++ b/app/components/hyper-table-v2/filtering-renderers/common/ordering.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/hypertable/components/hyper-table-v2/filtering-renderers/common/ordering';

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/ordering-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/ordering-test.ts
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+import TableHandler from '@upfluence/hypertable/core/handler';
+import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
+import { buildColumn } from '@upfluence/hypertable/test-support/table-manager';
+import { FieldSize } from '@upfluence/hypertable/core/interfaces';
+
+module('Integration | Component | hyper-table-v2/filtering-renderers/common/ordering', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.tableManager = new TableManager();
+    this.rowsFetcher = new RowsFetcher();
+    this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+
+    sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
+      return Promise.resolve({
+        columns: [buildColumn('date', { type: 'timestamp', size: FieldSize.Large, filterable: true, orderable: true })]
+      });
+    });
+
+    await this.handler.fetchColumns();
+
+    this.column = this.handler.columns[0];
+  });
+
+  test('it has the right data-control-name', async function (assert: Assert) {
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}} />`
+    );
+    assert.dom('.btn-group').exists();
+  });
+
+  test('it uses the default orderingOptions when no @customOrderingOptions are passed', async function (assert: Assert) {
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}} />`
+    );
+
+    assert.dom('.btn-group').exists();
+    assert.dom('.btn-group .btn').exists({ count: 2 });
+    assert.dom('.btn-group .btn:nth-child(1)').hasText('A — Z');
+    assert.dom('.btn-group .btn:nth-child(2)').hasText('Z — A');
+  });
+
+  test('it properly displays @customOrderingOptions when they are passed', async function (assert: Assert) {
+    this.customOrderingOptions = {
+      'Oldest — Newest': 'asc',
+      'Newest — Oldest': 'desc'
+    };
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}}
+                                                              @customOrderingOptions={{this.customOrderingOptions}} />`
+    );
+
+    assert.dom('.btn-group').exists();
+    assert.dom('.btn-group .btn').exists({ count: 2 });
+    assert.dom('.btn-group .btn:nth-child(1)').hasText('Oldest — Newest');
+    assert.dom('.btn-group .btn:nth-child(2)').hasText('Newest — Oldest');
+  });
+
+  test('it calls the Handler#applyOrder method correctly via the radio buttons', async function (assert: Assert) {
+    const handlerSpy = sinon.spy(this.handler);
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}} />`
+    );
+
+    assert.equal(this.column.order, undefined);
+
+    await click('.upf-radio-btn:first-child');
+    //@ts-ignore
+    assert.ok(handlerSpy.applyOrder.calledWith(this.column, 'asc'));
+    assert.deepEqual(this.column.order, {
+      direction: 'asc',
+      key: 'date'
+    });
+
+    await click('.upf-radio-btn:last-child');
+    //@ts-ignore
+    assert.ok(handlerSpy.applyOrder.calledWith(this.column, 'desc'));
+    assert.deepEqual(this.column.order, {
+      direction: 'desc',
+      key: 'date'
+    });
+  });
+});

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/ordering-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/ordering-test.ts
@@ -35,7 +35,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/orde
     assert.dom('.btn-group').exists();
   });
 
-  test('it uses the default orderingOptions when no @customOrderingOptions are passed', async function (assert: Assert) {
+  test('it uses the default orderingOptions when no @orderingOptions are passed', async function (assert: Assert) {
     await render(
       hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}} />`
     );
@@ -46,14 +46,14 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/orde
     assert.dom('.btn-group .btn:nth-child(2)').hasText('Z — A');
   });
 
-  test('it properly displays @customOrderingOptions when they are passed', async function (assert: Assert) {
-    this.customOrderingOptions = {
+  test('it properly displays @orderingOptions when they are passed', async function (assert: Assert) {
+    this.orderingOptions = {
       'Oldest — Newest': 'asc',
       'Newest — Oldest': 'desc'
     };
     await render(
       hbs`<HyperTableV2::FilteringRenderers::Common::Ordering @handler={{this.handler}} @column={{this.column}}
-                                                              @customOrderingOptions={{this.customOrderingOptions}} />`
+                                                              @orderingOptions={{this.orderingOptions}} />`
     );
 
     assert.dom('.btn-group').exists();


### PR DESCRIPTION
Refactored Date, Text & Numeric Filter renderers

### What does this PR do?

Created Ordering component for filter renderers that is located in the filter-renderers/common folder
Refactored Text, Date & Numeric filter renderers to use this new component
Added tests for this component

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
