### PR TITLE
Added: Search Common component for filter renderers

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/search.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/search.hbs
@@ -1,0 +1,13 @@
+<div data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_filters"}}>
+  <div class="margin-top-xxx-sm">
+    <label>{{t "hypertable.column.filtering.search_term.label"}}</label>
+    <OSS::InputContainer @value={{this.searchQuery}} @onChange={{this.onInputChanged}}
+                         @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}}>
+      <:suffix>
+        {{#if (gt this.searchQuery.length 0)}}
+          <i class="fa fa-remove" role="button" {{on "click" this.onClearSearch}}></i>
+        {{/if}}
+      </:suffix>
+    </OSS::InputContainer>
+  </div>
+</div>

--- a/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
@@ -9,7 +9,7 @@ import { Column } from '@upfluence/hypertable/core/interfaces';
 interface HyperTableV2FilteringRenderersSearchArgs {
   handler: TableHandler;
   column: Column;
-  registerResetCallback: any;
+  registerResetCallback(any: (...args: any[]) => void): void;
 }
 
 const SEARCH_DEBOUNCE_TIME: number = 300;

--- a/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
@@ -1,0 +1,57 @@
+import { action } from '@ember/object';
+import { debounce } from '@ember/runloop';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import TableHandler from '@upfluence/hypertable/core/handler';
+import { Column } from '@upfluence/hypertable/core/interfaces';
+
+interface HyperTableV2FilteringRenderersSearchArgs {
+  handler: TableHandler;
+  column: Column;
+  registerResetCallback: any;
+}
+
+const SEARCH_DEBOUNCE_TIME: number = 300;
+
+export default class HyperTableV2FilteringRenderersSearch extends Component<HyperTableV2FilteringRenderersSearchArgs> {
+  @tracked searchQuery: string = '';
+
+  constructor(owner: unknown, args: HyperTableV2FilteringRenderersSearchArgs) {
+    super(owner, args);
+
+    if (typeof this.args.registerResetCallback !== 'function') {
+      throw new Error(
+        '[HyperTableV2::FilteringRenderers::Common::Search] You need to link a method to reset your search input'
+      );
+    }
+    const searchTerm = this.args.column.filters.find((filter) => filter.key === 'value');
+    this.searchQuery = searchTerm?.value || '';
+    this.args.registerResetCallback(this._resetSearchQuery.bind(this));
+  }
+
+  @action
+  onInputChanged(): void {
+    debounce(this, this._applyFilters, SEARCH_DEBOUNCE_TIME);
+  }
+
+  @action
+  onClearSearch(event: MouseEvent): void {
+    event.stopPropagation();
+    this.searchQuery = '';
+    this._applyFilters();
+  }
+
+  private _applyFilters(): void {
+    this.args.handler.applyFilters(this.args.column, [
+      {
+        key: 'value',
+        value: this.searchQuery
+      }
+    ]);
+  }
+
+  private _resetSearchQuery(): void {
+    this.searchQuery = '';
+  }
+}

--- a/addon/components/hyper-table-v2/filtering-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.hbs
@@ -6,14 +6,8 @@
   {{/if}}
 
   {{#if @column.definition.filterable}}
-    <div class={{if @column.definition.orderable "margin-top-xx-sm"}}
-         data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_filters"}}>
-      <div class="margin-top-xxx-sm">
-        <label>{{t "hypertable.column.filtering.search_term.label"}}</label>
-        <OSS::InputContainer @value={{this.searchQuery}}
-                             @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}} />
-      </div>
-    </div>
+    <HyperTableV2::FilteringRenderers::Common::Search @handler={{@handler}} @column={{@column}}
+                                                      @registerResetCallback={{this.registerResetCallback}} />
   {{/if}}
 
   <div class="margin-top-xx-sm fx-row fx-malign-space-between">

--- a/addon/components/hyper-table-v2/filtering-renderers/text.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.ts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
@@ -11,33 +10,17 @@ interface HyperTableV2FilteringRenderersTextArgs {
 }
 
 export default class HyperTableV2FilteringRenderersText extends Component<HyperTableV2FilteringRenderersTextArgs> {
-  @tracked _searchQuery: string = '';
+  _childResetCallback: any;
 
-  constructor(owner: unknown, args: HyperTableV2FilteringRenderersTextArgs) {
-    super(owner, args);
-
-    const searchTerm = this.args.column.filters.find((filter) => filter.key === 'value');
-    this._searchQuery = searchTerm?.value || '';
-  }
-
-  get searchQuery(): string {
-    return this._searchQuery;
-  }
-
-  set searchQuery(value: string) {
-    this._searchQuery = value;
-
-    this.args.handler.applyFilters(this.args.column, [
-      {
-        key: 'value',
-        value
-      }
-    ]);
+  @action registerResetCallback(childResetMethod: () => {}): void {
+    this._childResetCallback = childResetMethod;
   }
 
   @action
   reset(): void {
-    this._searchQuery = '';
+    if (this._childResetCallback) {
+      this._childResetCallback();
+    }
     this.args.handler.resetColumns([this.args.column]);
   }
 

--- a/addon/components/hyper-table-v2/filtering-renderers/text.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/text.ts
@@ -12,15 +12,14 @@ interface HyperTableV2FilteringRenderersTextArgs {
 export default class HyperTableV2FilteringRenderersText extends Component<HyperTableV2FilteringRenderersTextArgs> {
   _childResetCallback: any;
 
-  @action registerResetCallback(childResetMethod: () => {}): void {
+  @action
+  registerResetCallback(childResetMethod: () => {}): void {
     this._childResetCallback = childResetMethod;
   }
 
   @action
   reset(): void {
-    if (this._childResetCallback) {
-      this._childResetCallback();
-    }
+    this._childResetCallback?.();
     this.args.handler.resetColumns([this.args.column]);
   }
 

--- a/app/components/hyper-table-v2/filtering-renderers/common/search.js
+++ b/app/components/hyper-table-v2/filtering-renderers/common/search.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/hypertable/components/hyper-table-v2/filtering-renderers/common/search';

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/search-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/search-test.ts
@@ -1,0 +1,116 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, render, triggerKeyEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+import TableHandler from '@upfluence/hypertable/core/handler';
+import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
+import { buildColumn } from '@upfluence/hypertable/test-support/table-manager';
+import { FieldSize } from '@upfluence/hypertable/core/interfaces';
+import settled from '@ember/test-helpers/settled';
+
+module('Integration | Component | hyper-table-v2/filtering-renderers/common/search', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.tableManager = new TableManager();
+    this.rowsFetcher = new RowsFetcher();
+    this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+
+    sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
+      return Promise.resolve({
+        columns: [buildColumn('Name', { type: 'text', size: FieldSize.Large, filterable: true, orderable: true })]
+      });
+    });
+
+    await this.handler.fetchColumns();
+
+    this.column = this.handler.columns[0];
+    this.registerCallback = () => {};
+  });
+
+  test('it has the right data-control-name', async function (assert: Assert) {
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.registerCallback}} />`
+    );
+    assert.dom('.oss-input-container').exists();
+  });
+
+  test('When text is inputed, the applyFilters is called', async function (assert: Assert) {
+    const handlerSpy = sinon.spy(this.handler);
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.registerCallback}} />`
+    );
+
+    await fillIn('.oss-input-container input', 'test');
+    await triggerKeyEvent(
+      '.oss-input-container input',
+      'keyup',
+      'Enter',
+      //@ts-ignore
+      { code: 'Enter' }
+    );
+
+    assert.ok(
+      //@ts-ignore
+      handlerSpy.applyFilters.calledWith(this.column, [
+        {
+          key: 'value',
+          value: 'test'
+        }
+      ])
+    );
+  });
+
+  test('The remove icon is displayed when text is entered', async function (assert: Assert) {
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.registerCallback}} />`
+    );
+    assert.dom('.oss-input-container').exists();
+    await fillIn('.oss-input-container input', 'test');
+    assert.dom('.oss-input-container .suffix .fa-remove').exists();
+  });
+
+  test('The remove icon is hidden when the input is empty', async function (assert: Assert) {
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.registerCallback}} />`
+    );
+    assert.dom('.oss-input-container').exists();
+    assert.dom('.oss-input-container .suffix .fa-remove').doesNotExist();
+  });
+
+  test('When the remove icon is clicked, the text input is cleared, #handler.applyFilters is triggered', async function (assert: Assert) {
+    const handlerSpy = sinon.spy(this.handler);
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.registerCallback}} />`
+    );
+    assert.dom('.oss-input-container').exists();
+    await fillIn('.oss-input-container input', 'test');
+    await click('.oss-input-container .suffix .fa-remove');
+    assert.ok(
+      //@ts-ignore
+      handlerSpy.applyFilters.calledWith(this.column, [
+        {
+          key: 'value',
+          value: ''
+        }
+      ])
+    );
+  });
+
+  test('When the parent triggers the reset event, the text input is cleared', async function (assert: Assert) {
+    this.resetTrigger = (childResetMethod: () => {}) => {
+      this._childResetCallback = childResetMethod;
+    };
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @registerResetCallback={{this.resetTrigger}} />`
+    );
+    assert.dom('.oss-input-container').exists();
+    await fillIn('.oss-input-container input', 'test');
+    assert.dom('.oss-input-container input').hasValue('test');
+    this._childResetCallback();
+    await settled();
+    assert.dom('.oss-input-container input').hasValue('');
+  });
+});

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/text-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/text-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -87,25 +87,6 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/text', func
       await render(hbs`<HyperTableV2::FilteringRenderers::Text @handler={{this.handler}} @column={{this.column}} />`);
 
       assert.dom('div[data-control-name="hypertable__column_filtering_for_foo_filters"]').exists();
-    });
-
-    test('it handles search term filters correctly', async function (assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
-      await render(hbs`<HyperTableV2::FilteringRenderers::Text @handler={{this.handler}} @column={{this.column}} />`);
-
-      await fillIn(
-        'div[data-control-name="hypertable__column_filtering_for_foo_filters"] .oss-input-container input',
-        'bar'
-      );
-
-      //@ts-ignore
-      assert.ok(handlerSpy.applyFilters.calledWith(this.column, [{ key: 'value', value: 'bar' }]));
-      assert.deepEqual(this.column.filters, [
-        {
-          key: 'value',
-          value: 'bar'
-        }
-      ]);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Refactored Date, Text & Numeric Filter renderers
Created Search component for filter renderers that is located in the filter-renderers/common folder
Refactored Text filter renderers to use this new component
Added tests for this component

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
