### PR TITLE
Integrate the addition of the Descriptors in the column definitions

### DIFF
--- a/addon-test-support/table-manager.ts
+++ b/addon-test-support/table-manager.ts
@@ -20,8 +20,11 @@ export const buildColumnDefinition = (key: string, extra?: { [key: string]: any 
     category: '',
     size: FieldSize.Medium,
     orderable: false,
+    orderable_by: [],
     filterable: false,
-    facetable: false
+    filterable_by: [],
+    facetable: false,
+    facetable_by: ['value']
   };
 
   return Object.assign(defaultColumnDefinition, extra || {});

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -96,10 +96,11 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
 
   private fetchFacets(): void {
     this.loading = true;
+    this.args.column.definition.facetable_by = null;
     this.args.handler
       .fetchFacets(
         this.args.column.definition.key,
-        this.args.column.definition.facetable_by[0] || 'value',
+        this.args.column.definition.facetable_by?.[0] || 'value',
         this.searchQuery
       )
       .then(({ facets, filtering_key }: FacetsResponse) => {

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -97,7 +97,11 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
   private fetchFacets(): void {
     this.loading = true;
     this.args.handler
-      .fetchFacets(this.args.column.definition.key, this.args.facettingKey, this.searchQuery)
+      .fetchFacets(
+        this.args.column.definition.key,
+        this.args.column.definition.facetable_by[0] || 'value',
+        this.searchQuery
+      )
       .then(({ facets, filtering_key }: FacetsResponse) => {
         this.facets = facets;
         this.filteringKey = filtering_key;

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -14,8 +14,11 @@ export type ColumnDefinition = {
   category: string;
   size: FieldSize;
   orderable: boolean;
+  orderable_by: string[];
   filterable: boolean;
+  filterable_by: string[];
   facetable: boolean;
+  facetable_by: string[];
 };
 
 export type Filter = {

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -14,11 +14,11 @@ export type ColumnDefinition = {
   category: string;
   size: FieldSize;
   orderable: boolean;
-  orderable_by: string[];
+  orderable_by: string[] | null;
   filterable: boolean;
-  filterable_by: string[];
+  filterable_by: string[] | null;
   facetable: boolean;
-  facetable_by: string[];
+  facetable_by: string[] | null;
 };
 
 export type Filter = {

--- a/addon/core/rendering-resolver.ts
+++ b/addon/core/rendering-resolver.ts
@@ -31,13 +31,13 @@ const rendererMatchers: { [key: string]: RendererDictionaryItem } = {
 };
 
 export default class implements RendererResolver {
-  private _context;
+  protected context: unknown;
 
   constructor(emberContext: unknown) {
-    this._context = emberContext;
+    this.context = emberContext;
   }
 
-  private _lookupComponent(
+  lookupComponent(
     columnDef: ColumnDefinition,
     rendererType: 'header' | 'cell' | 'filter'
   ): Promise<ResolvedRenderingComponent> {
@@ -45,20 +45,20 @@ export default class implements RendererResolver {
       component: ensureSafeComponent(
         (rendererMatchers[columnDef.type] || rendererMatchers.default)[rendererType] ||
           rendererMatchers.default[rendererType],
-        this._context
+        this.context
       ) as GlimmerComponent
     });
   }
 
   lookupHeaderComponent(columnDef: ColumnDefinition): Promise<ResolvedRenderingComponent> {
-    return this._lookupComponent(columnDef, 'header');
+    return this.lookupComponent(columnDef, 'header');
   }
 
   lookupCellComponent(columnDef: ColumnDefinition): Promise<ResolvedRenderingComponent> {
-    return this._lookupComponent(columnDef, 'cell');
+    return this.lookupComponent(columnDef, 'cell');
   }
 
   lookupFilteringComponent(columnDef: ColumnDefinition): Promise<ResolvedRenderingComponent> {
-    return this._lookupComponent(columnDef, 'filter');
+    return this.lookupComponent(columnDef, 'filter');
   }
 }

--- a/tests/dummy/app/controllers/application.ts
+++ b/tests/dummy/app/controllers/application.ts
@@ -39,8 +39,11 @@ const buildColumnDefinition = (key: string, extra: { [key: string]: any }): Colu
     category: '',
     size: FieldSize.Medium,
     orderable: true,
+    orderable_by: [],
     filterable: false,
-    facetable: false
+    filterable_by: [],
+    facetable: false,
+    facetable_by: ['value']
   };
 
   return Object.assign(defaultColumnDefinition, extra);

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
@@ -24,7 +24,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
     test('the facets are displayed correctly using the dedicated named block', async function (assert: Assert) {
       await render(
         hbs`
-          <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}>
+          <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}>
             <:facet-item as |facetting|>
               {{facetting.facet.payload.name}}
             </:facet-item>
@@ -41,35 +41,34 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       const handlerSpy = sinon.spy(this.handler);
 
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}/>`
       );
 
       assert.dom('.hypertable__facetting .item .upf-checkbox input').isNotChecked();
       await click('.hypertable__facetting .item');
       assert.dom('.hypertable__facetting .item .upf-checkbox input').isChecked();
       //@ts-ignore
-      assert.ok(handlerSpy.applyFilters.calledWithExactly(this.column, [{ key: 'foo', value: 'band:1' }]));
+      assert.ok(handlerSpy.applyFilters.calledWithExactly(this.column, [{ key: 'value', value: 'band:1' }]));
     });
 
     test('the facet is deleted from the filters if already present', async function (assert: Assert) {
-      this.column.filters = [{ key: 'foo', value: 'band:1' }];
+      this.column.filters = [{ key: 'value', value: 'band:1' }];
       const handlerSpy = sinon.spy(this.handler);
 
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}/>`
       );
-
       assert.dom('.hypertable__facetting .item .upf-checkbox input').isChecked();
       await click('.hypertable__facetting .item');
       //@ts-ignore
-      assert.ok(handlerSpy.applyFilters.calledWithExactly(this.column, [{ key: 'foo', value: '' }]));
+      assert.ok(handlerSpy.applyFilters.calledWithExactly(this.column, [{ key: 'value', value: '' }]));
     });
 
     test('facet identifiers that are already in the column are checked by default when rendering', async function (assert: Assert) {
-      this.column.filters = [{ key: 'foo', value: 'band:1' }];
+      this.column.filters = [{ key: 'value', value: 'band:1' }];
 
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}/>`
       );
 
       assert.dom('.hypertable__facetting .item .upf-checkbox input').isChecked();
@@ -79,7 +78,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
   module('facets search', function () {
     test('the search is not displayed when the searchEnabled argument is falsy', async function (assert: Assert) {
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}/>`
       );
 
       assert.dom('.oss-input-container').doesNotExist();
@@ -87,7 +86,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
 
     test('the search is displayed when the searchEnabled argument is truthy', async function (assert: Assert) {
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{true}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{true}}/>`
       );
 
       assert.dom('.oss-input-container').exists();
@@ -97,7 +96,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       const handlerSpy = sinon.spy(this.handler);
 
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{true}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{true}}/>`
       );
 
       await fillIn('.oss-input-container input', 'test');
@@ -110,7 +109,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       );
 
       //@ts-ignore
-      assert.ok(handlerSpy.fetchFacets.calledWithExactly(this.column.definition.key, 'foo', 'test'));
+      assert.ok(handlerSpy.fetchFacets.calledWithExactly(this.column.definition.key, 'value', 'test'));
     });
   });
 
@@ -124,7 +123,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       });
 
       await render(
-        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{true}}/>`
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{true}}/>`
       );
 
       assert
@@ -139,13 +138,13 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       sinon.stub(this.tableManager, 'fetchFacets').callsFake(() => {
         return Promise.resolve({
           facets: [],
-          filtering_key: 'foo'
+          filtering_key: 'value'
         });
       });
 
       await render(
         hbs`
-          <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @facettingKey="foo" @searchEnabled={{false}}>
+          <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}>
             <:facet-item as |facetting|>
               {{facetting.facet.payload.name}}
             </:facet-item>

--- a/tests/integration/components/hyper-table-v2/manage-columns-test.ts
+++ b/tests/integration/components/hyper-table-v2/manage-columns-test.ts
@@ -187,8 +187,11 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               category: 'affiliation',
               size: 'M',
               orderable: false,
+              orderable_by: [],
               filterable: false,
-              facetable: false
+              filterable_by: [],
+              facetable: false,
+              facetable_by: ['value']
             },
             filters: []
           },
@@ -201,8 +204,11 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               category: 'influencer',
               size: 'M',
               orderable: false,
+              orderable_by: [],
               filterable: false,
-              facetable: false
+              filterable_by: [],
+              facetable: false,
+              facetable_by: ['value']
             },
             filters: []
           }

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -51,8 +51,11 @@ module('Unit | core/handler', function (hooks) {
       category: '',
       size: FieldSize.Medium,
       orderable: false,
+      orderable_by: [],
       filterable: false,
-      facetable: false
+      filterable_by: [],
+      facetable: false,
+      facetable_by: ['value']
     });
 
     assert.equal(handler.columns.length, 1);
@@ -71,8 +74,11 @@ module('Unit | core/handler', function (hooks) {
           category: '',
           size: FieldSize.Medium,
           orderable: false,
+          orderable_by: [],
           filterable: false,
-          facetable: false
+          filterable_by: [],
+          facetable: false,
+          facetable_by: ['value']
         },
         filters: []
       }


### PR DESCRIPTION
### What does this PR do?

Integrate the addition of the Descriptors in the column definitions
* Data models have been updated
* The FacetLoader component has been updated to use the faceting_by key provided in the column definition or to default back to "value" if nothing exists.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled