### PR TITLE
Fix display of to and from value in numeric filter

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/numeric.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/numeric.ts
@@ -30,6 +30,9 @@ export default class HyperTableV2FilteringRenderersNumeric extends Component<Hyp
         this._resetStates();
       }
     });
+
+    this.lowerBoundFilter = args.column.filters.find((filter) => filter.key === 'lower_bound')?.value || '';
+    this.upperBoundFilter = args.column.filters.find((filter) => filter.key === 'upper_bound')?.value || '';
   }
 
   get hasBoundFiltersDefined(): boolean {

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/numeric-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/numeric-test.ts
@@ -175,6 +175,22 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/numeric', f
         ])
       );
     });
+
+    module('with existing range value', function () {
+      test('it display range value', async function (assert: Assert) {
+        this.column.filters = [
+          { key: 'lower_bound', value: '10' },
+          { key: 'upper_bound', value: '1000' }
+        ];
+
+        await render(
+          hbs`<HyperTableV2::FilteringRenderers::Numeric @handler={{this.handler}} @column={{this.column}} />`
+        );
+
+        assert.dom('[data-control-name="hypertable__column_filtering_for_total_range_from"]').hasValue('10');
+        assert.dom('[data-control-name="hypertable__column_filtering_for_total_range_to"]').hasValue('1000');
+      });
+    });
   });
 
   module('clear column', async function () {


### PR DESCRIPTION
### What does this PR do?

Fix display of to and from value in numeric filter

Related to : https://github.com/upfluence/backlog/issues/1297

### What are the observable changes?
![Peek 2022-02-10 11-54](https://user-images.githubusercontent.com/43567222/153392629-149fa2e3-ff0d-4838-93aa-2238be5a5149.gif)

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
