### PR TITLE
Add apply-filter trigger event

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -46,7 +46,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
     let filter = this.args.column.filters.find((f) => f.key === 'value');
     this._currentMovingDateOption = filter ? filter.value : null;
     this.filterOption = this._currentMovingDateOption ? 'moving' : 'fixed';
-    args.handler.on('reset-columns', (columns) => {
+    args.handler.on('reset-columns', (columns) => {
       if (columns.includes(args.column)) {
         this._resetStates();
       }

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -209,7 +209,7 @@ export default class TableHandler {
 
     return this.tableManager.upsertColumns({ columns: this.columns }).then(({ columns }) => {
       this._reinitColumnsAndRows(columns);
-      this.triggerEvent('apply-filter', column, filters);
+      this.triggerEvent('apply-filters', column, filters);
     });
   }
 

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -125,7 +125,7 @@ export default class TableHandler {
   /**
    * Attach a handler to a specific event in the handler's lifecycle.
    *
-   * @param {string} event — The event to subscribe to.
+   * @param {string} event — The event to subscribe to.
    * @param {Function} handler - A callback function to be called when the subscribed event is triggered.
    * @returns {TableHandler}
    */
@@ -209,14 +209,15 @@ export default class TableHandler {
 
     return this.tableManager.upsertColumns({ columns: this.columns }).then(({ columns }) => {
       this._reinitColumnsAndRows(columns);
+      this.triggerEvent('apply-filter', column, filters);
     });
   }
 
   /**
    * Apply ordering to a column
    *
-   * @param {Column} column — The column we want to order by
-   * @param {OrderDirection} direction — The direction we want to order the column in
+   * @param {Column} column — The column we want to order by
+   * @param {OrderDirection} direction — The direction we want to order the column in
    * @returns {Promise<void>}
    */
   async applyOrder(column: Column, direction: OrderDirection): Promise<void> {

--- a/app/styles/inner-table.less
+++ b/app/styles/inner-table.less
@@ -34,7 +34,7 @@
     border-right: 1px solid darken(@upf-gray-light, 10%);
   }
 
-  &:nth-child(2) header {
+  &:nth-child(2) header {
     border-right: none;
   }
   &:first-child {

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -107,6 +107,15 @@ module('Unit | core/handler', function (hooks) {
       ]);
     });
 
+    test('new filters trigger event with the apply-filters event', async function (assert: Assert) {
+      const handlerSpy = sinon.spy(this.handler, 'triggerEvent');
+      await this.handler.applyFilters(this.handler.columns[0], [{ key: 'foo', value: 'bar' }]);
+
+      assert.ok(
+        handlerSpy.calledOnceWithExactly('apply-filters', this.handler.columns[0], [{ key: 'foo', value: 'bar' }])
+      );
+    });
+
     test('existing filters are updated if they have the same key', function (assert: Assert) {
       this.handler.columns[0].filters = [{ key: 'foo', value: 'bar' }];
 


### PR DESCRIPTION
### What does this PR do?

Add apply-filter trigger event. It is using in the threads stats footer to re-call stats after a change

Related to : https://github.com/upfluence/backlog/issues/1314

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled