### PR TITLE
Add resetRows in handler & manage loading state

### DIFF
--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -252,6 +252,17 @@ export default class TableHandler {
   }
 
   /**
+   * Reset rows
+   *
+   * @returns {Promise<void>}
+   */
+  async resetRows(): Promise<void> {
+    this.rows = [];
+    this.currentPage = 1;
+    return this.fetchRows();
+  }
+
+  /**
    * Fetches more rows if there are any.
    *
    * @returns {void}

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -146,6 +146,20 @@ module('Unit | core/handler', function (hooks) {
     assert.equal(handler.columns[1].order, undefined);
   });
 
+  test('Handler#resetRows', async function (assert: Assert) {
+    const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+    const rowsFetcherSpy = sinon.spy(this.rowsFetcher);
+
+    await handler.fetchRows();
+    await handler.resetRows();
+
+    // @ts-ignore
+    assert.ok(rowsFetcherSpy.fetch.calledTwice);
+    // @ts-ignore
+    assert.ok(rowsFetcherSpy.fetch.calledWithExactly(1, 20));
+    assert.equal(handler.rows.length, 2);
+  });
+
   test('Handler#applyOrder', async function (assert: Assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
     const tableManagerSpy = sinon.spy(this.tableManager);


### PR DESCRIPTION
### What does this PR do?

Add resetRows in handler to reset the current rows
Set loading to true before th init

Related to : https://github.com/upfluence/backlog/issues/1320

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
