### PR TITLE
filters/common/existence: allow passing down a filtering key

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/existence.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/existence.ts
@@ -10,9 +10,12 @@ interface HyperTableV2FilteringRenderersExistenceArgs {
   handler: TableHandler;
   column: Column;
   label?: string;
+  filteringKey?: string;
   existenceFilters?: { [key: string]: OrderDirection };
   activateWithValue?: boolean;
 }
+
+const defaultFilteringKey = 'existence';
 
 const defaultExistenceFilters = {
   'With Value': 'with',
@@ -54,9 +57,13 @@ export default class HyperTableV2FilteringRenderersExistence extends Component<H
     return this._currentSelection || this.args.activateWithValue ? 'with' : null;
   }
 
+  get _filteringKey(): string {
+    return this.args.filteringKey || defaultFilteringKey;
+  }
+
   @action
   existenceFilterChanged(value: string): void {
-    this.args.handler.applyFilters(this.args.column, [{ key: 'existence', value }]).then(() => {
+    this.args.handler.applyFilters(this.args.column, [{ key: this._filteringKey, value }]).then(() => {
       this._currentSelection = value;
     });
   }

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/existence-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/existence-test.ts
@@ -50,6 +50,21 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/exis
     assert.ok(handlerSpy.applyFilters.calledWith(this.column, [{ key: 'existence', value: 'without' }]));
   });
 
+  test('cliking on the buttons should trigger the applyFilters method with a custom filtering key', async function (assert: Assert) {
+    const handlerSpy = sinon.spy(this.handler);
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Existence @filteringKey="bozo" @handler={{this.handler}} @column={{this.column}} />`
+    );
+
+    await click('.btn-group .btn:first-child');
+    // @ts-ignore
+    assert.ok(handlerSpy.applyFilters.calledWith(this.column, [{ key: 'bozo', value: 'with' }]));
+
+    await click('.btn-group .btn:last-child');
+    // @ts-ignore
+    assert.ok(handlerSpy.applyFilters.calledWith(this.column, [{ key: 'bozo', value: 'without' }]));
+  });
+
   test('if a label is provided, it is displayed', async function (assert: Assert) {
     await render(
       hbs`<HyperTableV2::FilteringRenderers::Common::Existence @handler={{this.handler}} @column={{this.column}} @label="test" />`


### PR DESCRIPTION
### What does this PR do?

This PR adds `filteringKey` argument to the `existence filter` as this kind of filter could be used for another filtering key.

It should be renamed to `RadioButton` filter, though for compatibility sake, we're not going to do this just yet. 

Related to : https://github.com/upfluence/backlog/issues/1368

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
