### PR TITLE
Added: Search now uses column definition attribute if it exists

### DIFF
--- a/addon/components/hyper-table-v2/search.ts
+++ b/addon/components/hyper-table-v2/search.ts
@@ -15,6 +15,15 @@ export default class HyperTableV2Search extends Component<HyperTableV2SearchArgs
   @service declare intl: any;
   @tracked searchQuery: string = '';
 
+  constructor(owner: any, args: HyperTableV2SearchArgs) {
+    super(owner, args);
+    args.handler.on('reset-columns', (columns) => {
+      if (columns.includes(args.handler?.columns[0])) {
+        this.onClearSearch();
+      }
+    });
+  }
+
   get searchPlaceholder(): string {
     if (this.args.handler?.columns[0]?.definition?.name)
       return this.intl.t('hypertable.header.search_by') + ' ' + this.args.handler.columns[0].definition.name;

--- a/addon/components/hyper-table-v2/search.ts
+++ b/addon/components/hyper-table-v2/search.ts
@@ -35,7 +35,7 @@ export default class HyperTableV2Search extends Component<HyperTableV2SearchArgs
   private _applySearchFilter(): void {
     this.args.handler.applyFilters(this.args.handler.columns[0], [
       {
-        key: 'value',
+        key: this.args.handler?.columns[0]?.definition?.filterable_by?.[0] || 'value',
         value: this.searchQuery
       }
     ]);


### PR DESCRIPTION
### What does this PR do?

Use filterable_by from the column definition when available and default to 'value' if none exist.

Also listen for 'reset-columns' from the handler to reset the search filter.

Related to : #[1357](https://github.com/upfluence/backlog/issues/1357)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled