### PR TITLE
Hide the first column from the Manage Fields component

### DIFF
--- a/addon/components/hyper-table-v2/column.hbs
+++ b/addon/components/hyper-table-v2/column.hbs
@@ -30,7 +30,9 @@
         </div>
       {{/if}}
 
-      <i class="fas fa-bars fa-rotate-90"></i>
+      {{#if this.displayMoveIndicator}}
+        <i class="fas fa-bars fa-rotate-90"></i>
+      {{/if}}
     </div>
   </header>
 

--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -19,6 +19,8 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
   @tracked filteringComponent?: ResolvedRenderingComponent;
   @tracked displayFilteringComponent: boolean = false;
 
+  displayMoveIndicator: boolean;
+
   constructor(owner: unknown, args: HyperTableV2ColumnArgs) {
     super(owner, args);
 
@@ -30,6 +32,8 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
       .finally(() => {
         this.loadingHeaderComponent = false;
       });
+
+    this.displayMoveIndicator = args.handler.columnPosition(args.column) !== 0;
 
     if (args.column.definition.orderable || args.column.definition.filterable) {
       args.handler.renderingResolver

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -76,7 +76,6 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
   columnVisibilityUpdate(column: ManagedColumn, event: PointerEvent): void {
     event.stopPropagation();
     if (column.visible) {
-      console.log('handler removeColumn');
       this.args.handler.removeColumn(column.definition);
     } else {
       this.args.handler.addColumn(column.definition).then(() => {

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -50,6 +50,12 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     const map = new Map();
 
     columnDefinitions.forEach((columnDefinition) => {
+      if (
+        this.args.handler.columns.length > 0 &&
+        this.args.handler.columns[0].definition.name === columnDefinition.name
+      ) {
+        return;
+      }
       const cluster = map.get(columnDefinition.clustering_key);
       const manageColumn: ManagedColumn = {
         definition: columnDefinition,
@@ -70,6 +76,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
   columnVisibilityUpdate(column: ManagedColumn, event: PointerEvent): void {
     event.stopPropagation();
     if (column.visible) {
+      console.log('handler removeColumn');
       this.args.handler.removeColumn(column.definition);
     } else {
       this.args.handler.addColumn(column.definition).then(() => {

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -52,7 +52,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     columnDefinitions.forEach((columnDefinition) => {
       if (
         this.args.handler.columns.length > 0 &&
-        this.args.handler.columns[0].definition.name === columnDefinition.name
+        this.args.handler.columns[0].definition.key === columnDefinition.key
       ) {
         return;
       }

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/numeric-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/numeric-test.ts
@@ -140,11 +140,15 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/numeric', f
 
     test('it triggers applyFilter when the range values are changed', async function (assert: Assert) {
       const handlerSpy = sinon.spy(this.handler);
+      //@ts-ignore
+      Ember.run.debounce = function (target: () => {}, func: () => {}) {
+        func.call(target);
+      };
       await render(
         hbs`<HyperTableV2::FilteringRenderers::Numeric @handler={{this.handler}} @column={{this.column}} />`
       );
 
-      await fillIn('[data-control-name="hypertable__column_filtering_for_total_range_from"]', '10');
+      await fillIn('[data-control-name="hypertable__column_filtering_for_total_range_from"]', '1');
       await triggerKeyEvent(
         '[data-control-name="hypertable__column_filtering_for_total_range_from"]',
         'keydown',
@@ -152,13 +156,12 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/numeric', f
         //@ts-ignore
         { code: 'Enter' }
       );
-
       assert.ok(
         //@ts-ignore
-        handlerSpy.applyFilters.calledWith(this.column, [{ key: 'lower_bound', value: '10' }])
+        handlerSpy.applyFilters.calledWith(this.column, [{ key: 'lower_bound', value: '1' }])
       );
 
-      await fillIn('[data-control-name="hypertable__column_filtering_for_total_range_to"]', '10000');
+      await fillIn('[data-control-name="hypertable__column_filtering_for_total_range_to"]', '9');
       await triggerKeyEvent(
         '[data-control-name="hypertable__column_filtering_for_total_range_to"]',
         'keydown',
@@ -170,8 +173,8 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/numeric', f
       assert.ok(
         //@ts-ignore
         handlerSpy.applyFilters.calledWith(this.column, [
-          { key: 'lower_bound', value: '10' },
-          { key: 'upper_bound', value: '10000' }
+          { key: 'lower_bound', value: '1' },
+          { key: 'upper_bound', value: '9' }
         ])
       );
     });


### PR DESCRIPTION
### What does this PR do?

Hide the first column from the Manage Fields component

Related to : #[1365](https://github.com/upfluence/backlog/issues/1356)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
