### PR TITLE
Fix hypertable performance issues

### DIFF
--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -4,7 +4,7 @@ import { action, set } from '@ember/object';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { Column, Row } from '@upfluence/hypertable/core/interfaces';
-import { scheduleOnce } from '@ember/runloop';
+import { debounce, scheduleOnce } from '@ember/runloop';
 
 type FeatureSet = {
   selection: boolean;
@@ -17,6 +17,7 @@ interface HyperTableV2Args {
 }
 
 const DEFAULT_FEATURES_SET: FeatureSet = { selection: false, searchable: true };
+const RESET_DEBOUNCE_TIME = 300;
 
 export default class HyperTableV2 extends Component<HyperTableV2Args> {
   loadingSkeletons = new Array(3);
@@ -86,10 +87,7 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
 
   @action
   resetFilters() {
-    this.loadingResetFilters = true;
-    this.args.handler.resetColumns(this.args.handler.columns).finally(() => {
-      this.loadingResetFilters = false;
-    });
+    debounce(this, this._resetFilters, RESET_DEBOUNCE_TIME);
   }
 
   @action
@@ -126,5 +124,12 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   @action
   reloadPage() {
     window.location.reload();
+  }
+
+  private _resetFilters(): void {
+    this.loadingResetFilters = true;
+    this.args.handler.resetColumns(this.args.handler.columns).finally(() => {
+      this.loadingResetFilters = false;
+    });
   }
 }

--- a/addon/components/hyper-table-v2/manage-columns.hbs
+++ b/addon/components/hyper-table-v2/manage-columns.hbs
@@ -36,7 +36,8 @@
               {{#if field.isLoading}}
                 <div><i class="fa fa-spinner fa-spin"></i></div>
               {{else}}
-                <OSS::Checkbox @checked={{field.visible}} @onChange={{fn this.columnVisibilityUpdate field}} @size="sm" />
+                <OSS::Checkbox @checked={{field.visible}} @onChange={{fn this.columnVisibilityUpdate field}} @size="sm" 
+                               data-control-name={{concat "column_definition_toggle_checkbox_" field.definition.key}} />
               {{/if}}
               <div class="margin-left-xxx-sm">
                 {{field.definition.name}}

--- a/addon/components/hyper-table-v2/manage-columns.hbs
+++ b/addon/components/hyper-table-v2/manage-columns.hbs
@@ -33,7 +33,11 @@
           {{/if}}
           {{#each fields as |field|}}
             <div class="field" role="button" {{on "click" (fn this.columnVisibilityUpdate field)}}>
-              <OSS::Checkbox @checked={{field.visible}} @onChange={{fn this.columnVisibilityUpdate field}} @size="sm" />
+              {{#if field.isLoading}}
+                <div><i class="fa fa-spinner fa-spin"></i></div>
+              {{else}}
+                <OSS::Checkbox @checked={{field.visible}} @onChange={{fn this.columnVisibilityUpdate field}} @size="sm" />
+              {{/if}}
               <div class="margin-left-xxx-sm">
                 {{field.definition.name}}
               </div>

--- a/addon/components/hyper-table-v2/manage-columns.hbs
+++ b/addon/components/hyper-table-v2/manage-columns.hbs
@@ -32,10 +32,8 @@
             </div>
           {{/if}}
           {{#each fields as |field|}}
-            <div class="field" {{on "click" (fn this.columnVisibilityUpdate field)}}>
-              <UpfCheckbox
-                @value={{field.visible}} @size="sm"
-                data-control-name={{concat "column_definition_toggle_checkbox_" field.definition.key}} />
+            <div class="field" role="button" {{on "click" (fn this.columnVisibilityUpdate field)}}>
+              <OSS::Checkbox @checked={{field.visible}} @onChange={{fn this.columnVisibilityUpdate field}} @size="sm" />
               <div class="margin-left-xxx-sm">
                 {{field.definition.name}}
               </div>

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -74,7 +74,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
 
   @action
   columnVisibilityUpdate(column: ManagedColumn, event: PointerEvent): void {
-    event.stopPropagation();
+    event?.stopPropagation?.();
     if (column.visible) {
       this.args.handler.removeColumn(column.definition);
     } else {

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -269,6 +269,7 @@ export default class TableHandler {
    */
   onBottomReached(): void {
     if (!this.rowsMeta || this.rowsMeta.total > this.rows.length) {
+    if (!this.loadingRows && (!this.rowsMeta || this.rowsMeta.total > this.rows.length)) {
       this.fetchRows();
     }
   }

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -268,7 +268,6 @@ export default class TableHandler {
    * @returns {void}
    */
   onBottomReached(): void {
-    if (!this.rowsMeta || this.rowsMeta.total > this.rows.length) {
     if (!this.loadingRows && (!this.rowsMeta || this.rowsMeta.total > this.rows.length)) {
       this.fetchRows();
     }


### PR DESCRIPTION
### What does this PR do?

* Fixed mutli call on load, column add/remove + onBottomReached
* Debounce reset filters button
* Added loading state on ManageField Column Add/Remove buttons
* Fixed multi calls on ManageField column button press
Related to : #[1348](https://github.com/upfluence/backlog/issues/1348)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled