### PR TITLE
Remove flatpickrRef in date filter

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/date.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.hbs
@@ -25,7 +25,7 @@
           <EmberFlatpickr @onChange={{this.selectFixedDate}} @dateFormat="M/D/Y"
                           @placeholder={{t "hypertable.column.filtering.date.range.label"}}
                           @mode="range" @date={{readonly this._currentDateValue}} @altInput={{true}}
-                          @altInputClass="upf-input upf-input--textarea" @getFlatpickrRef={{fn (mut this.flatpickrRef)}}
+                          @altInputClass="upf-input upf-input--textarea"
                           @onOpen={{this.openedFlatpickr}} @onClose={{this.closedFlatpickr}} />
         {{else}}
           {{#each-in this.movingDateOptions as |label value|}}

--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -14,7 +14,6 @@ interface HyperTableV2FilteringRenderersDateArgs {
 type FilterOption = 'moving' | 'fixed';
 
 export default class HyperTableV2FilteringRenderersDate extends Component<HyperTableV2FilteringRenderersDateArgs> {
-  @tracked flatpickrRef: any;
   @tracked _currentDateValue: Date[] = [];
   @tracked _currentMovingDateOption: any;
   @tracked filterOption: FilterOption;
@@ -113,8 +112,5 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   private _resetStates(): void {
     this._currentDateValue = [];
     this._currentMovingDateOption = [];
-    if (this.flatpickrRef) {
-      this.flatpickrRef.clear();
-    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Remove flatpickrRef. `flatpickrRef` is useless because when we reset filter, the filter is re-render with the correct value. 

Related to : https://github.com/upfluence/backlog/issues/1392

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
