### PR TITLE
filtering-renderers/date: fix filter application

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -42,7 +42,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   constructor(owner: unknown, args: HyperTableV2FilteringRenderersDateArgs) {
     super(owner, args);
 
-    let filter = this.args.column.filters.find((f) => f.key === 'value');
+    let filter = this.args.column.filters.find((f) => f.key === 'moving');
     this._currentMovingDateOption = filter ? filter.value : null;
     this.filterOption = this._currentMovingDateOption ? 'moving' : 'fixed';
     args.handler.on('reset-columns', (columns) => {
@@ -89,7 +89,11 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   @action
   selectMovingDate(value: any): void {
     this._currentMovingDateOption = value;
-    this.args.handler.applyFilters(this.args.column, [{ key: 'value', value: value }]);
+    this.args.handler.applyFilters(this.args.column, [
+      { key: 'lower_bound', value: '' },
+      { key: 'upper_bound', value: '' },
+      { key: 'moving', value: value }
+    ]);
   }
 
   @action
@@ -98,6 +102,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
 
     if (fromDate && toDate) {
       this.args.handler.applyFilters(this.args.column, [
+        { key: 'moving', value: '' },
         { key: 'lower_bound', value: (+fromDate / 1000).toString() },
         { key: 'upper_bound', value: (+toDate / 1000).toString() }
       ]);

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
@@ -125,7 +125,11 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
       await click('.filters__option');
       assert.ok(
         //@ts-ignore
-        handlerSpy.applyFilters.calledWith(this.column, [{ key: 'value', value: 'today' }])
+        handlerSpy.applyFilters.calledWith(this.column, [
+          { key: 'lower_bound', value: '' },
+          { key: 'upper_bound', value: '' },
+          { key: 'moving', value: 'today' },
+        ])
       );
     });
 
@@ -153,7 +157,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
   module('clear column', async function () {
     test('it calls the Handler#resetColumns with the column when the dedicated button is clicked', async function (assert: Assert) {
       const handlerSpy = sinon.spy(this.handler);
-      this.handler.applyFilters(this.column, [{ key: 'value', value: 'today' }]);
+      this.handler.applyFilters(this.column, [{ key: 'moving', value: 'today' }]);
       this.handler.applyOrder(this.column, 'asc');
 
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);


### PR DESCRIPTION
### What does this PR do?

This PR fixes the date filters logic:
- It sets the proper key `moving`
- It makes the `moving` and `range` filtering exclusive.

Related to : https://github.com/upfluence/backlog/issues/1391

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled