### PR TITLE
Trigger event on Handler.resetRows 

### DIFF
--- a/addon/components/hyper-table-v2/search.ts
+++ b/addon/components/hyper-table-v2/search.ts
@@ -19,7 +19,7 @@ export default class HyperTableV2Search extends Component<HyperTableV2SearchArgs
     super(owner, args);
     args.handler.on('reset-columns', (columns) => {
       if (columns.includes(args.handler?.columns[0])) {
-        this.onClearSearch();
+        this.searchQuery = '';
       }
     });
   }

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -259,7 +259,9 @@ export default class TableHandler {
   async resetRows(): Promise<void> {
     this.rows = [];
     this.currentPage = 1;
-    return this.fetchRows();
+    return this.fetchRows().then(() => {
+      this.triggerEvent('reset-rows');
+    });
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?

* handler.resetRows now trigger an event
* Fixed double call issue when clicking on reset-filters button
Related to : #[1393](https://github.com/upfluence/backlog/issues/1393)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled