### PR TITLE
Fixed: multi call on order filter - now throttled

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/ordering.ts
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { throttle } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -15,6 +16,8 @@ const defaultOrderingDirections: { [key: string]: OrderDirection } = {
   'A — Z': 'asc',
   'Z — A': 'desc'
 };
+
+const THROTTLE_TIME = 300;
 
 export default class HyperTableV2FilteringRenderersOrdering extends Component<HyperTableV2FilteringRenderersOrderingArgs> {
   @tracked _selectedDirection: OrderDirection | undefined;
@@ -39,6 +42,10 @@ export default class HyperTableV2FilteringRenderersOrdering extends Component<Hy
 
   @action
   orderingDirectionChanged(direction: OrderDirection): void {
+    throttle(this, this._applyOrdering, direction, THROTTLE_TIME);
+  }
+
+  private _applyOrdering(direction: OrderDirection): void {
     this.args.handler.applyOrder(this.args.column, direction).then(() => {
       this._selectedDirection = direction;
     });


### PR DESCRIPTION
### What does this PR do?

 multi call on order filter - now throttled

Related to : #[1400](https://github.com/upfluence/backlog/issues/1400)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled