### PR TITLE
Handle the sticky columns better

### DIFF
--- a/addon-test-support/table-manager.ts
+++ b/addon-test-support/table-manager.ts
@@ -24,7 +24,10 @@ export const buildColumnDefinition = (key: string, extra?: { [key: string]: any 
     filterable: false,
     filterable_by: [],
     facetable: false,
-    facetable_by: ['value']
+    facetable_by: ['value'],
+    position: {
+      sticky: false
+    }
   };
 
   return Object.assign(defaultColumnDefinition, extra || {});

--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -33,7 +33,7 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
         this.loadingHeaderComponent = false;
       });
 
-    this.displayMoveIndicator = args.column.definition.position?.sticky !== true;
+    this.displayMoveIndicator = !args.column.definition.position?.sticky;
 
     if (args.column.definition.orderable || args.column.definition.filterable) {
       args.handler.renderingResolver

--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -33,7 +33,7 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
         this.loadingHeaderComponent = false;
       });
 
-    this.displayMoveIndicator = !args.column.definition.position?.sticky;
+    this.displayMoveIndicator = args.column.definition.position?.sticky !== true;
 
     if (args.column.definition.orderable || args.column.definition.filterable) {
       args.handler.renderingResolver

--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -33,7 +33,7 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
         this.loadingHeaderComponent = false;
       });
 
-    this.displayMoveIndicator = args.handler.columnPosition(args.column) !== 0;
+    this.displayMoveIndicator = !args.column.definition.position?.sticky;
 
     if (args.column.definition.orderable || args.column.definition.filterable) {
       args.handler.renderingResolver

--- a/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
@@ -11,7 +11,7 @@ interface HyperTableV2FilteringRenderersCommonColumnActionsArgs {
 
 export default class HyperTableV2FilteringRenderersCommonColumnActions extends Component<HyperTableV2FilteringRenderersCommonColumnActionsArgs> {
   get shouldDisplay(): boolean {
-    return this.args.handler.columnPosition(this.args.column) !== 0;
+    return !this.args.column.definition.position?.sticky;
   }
 
   @action

--- a/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
@@ -11,7 +11,7 @@ interface HyperTableV2FilteringRenderersCommonColumnActionsArgs {
 
 export default class HyperTableV2FilteringRenderersCommonColumnActions extends Component<HyperTableV2FilteringRenderersCommonColumnActionsArgs> {
   get shouldDisplay(): boolean {
-    return this.args.column.definition.position?.sticky !== true;
+    return !this.args.column.definition.position?.sticky;
   }
 
   @action

--- a/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.ts
@@ -11,7 +11,7 @@ interface HyperTableV2FilteringRenderersCommonColumnActionsArgs {
 
 export default class HyperTableV2FilteringRenderersCommonColumnActions extends Component<HyperTableV2FilteringRenderersCommonColumnActionsArgs> {
   get shouldDisplay(): boolean {
-    return !this.args.column.definition.position?.sticky;
+    return this.args.column.definition.position?.sticky !== true;
   }
 
   @action

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -98,8 +98,9 @@
           {{/if}}
 
           {{#if (gt index 0)}}
-            <HyperTableV2::Column @handler={{@handler}} @column={{column}}
-                                  {{sortable-item model=column spacing=5 distance=10}}>
+            <HyperTableV2::Column
+              @handler={{@handler}} @column={{column}}
+              {{sortable-item model=column spacing=5 distance=10 disabled=column.definition.position.sticky}}>
               {{#each @handler.rows as |row|}}
                 <HyperTableV2::Cell @handler={{@handler}} @column={{column}} @row={{row}} @onClick={{this.onRowClick}}
                                     @onHover={{this.onRowHover}} />

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -52,7 +52,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     const map = new Map();
 
     columnDefinitions.forEach((columnDefinition) => {
-      if (this.args.handler.columns.length > 0 && columnDefinition.position?.sticky === true) {
+      if (this.args.handler.columns.length > 0 && columnDefinition.position?.sticky) {
         return;
       }
       const cluster = map.get(columnDefinition.clustering_key);

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -52,7 +52,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     const map = new Map();
 
     columnDefinitions.forEach((columnDefinition) => {
-      if (this.args.handler.columns.length > 0 && columnDefinition.position?.sticky) {
+      if (this.args.handler.columns.length > 0 && columnDefinition.position?.sticky === true) {
         return;
       }
       const cluster = map.get(columnDefinition.clustering_key);

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -52,10 +52,7 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     const map = new Map();
 
     columnDefinitions.forEach((columnDefinition) => {
-      if (
-        this.args.handler.columns.length > 0 &&
-        this.args.handler.columns[0].definition.key === columnDefinition.key
-      ) {
+      if (this.args.handler.columns.length > 0 && columnDefinition.position?.sticky) {
         return;
       }
       const cluster = map.get(columnDefinition.clustering_key);

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -368,7 +368,7 @@ export default class TableHandler {
       if (existingColumn) {
         existingColumn = column;
       } else {
-        this.columns.push(column);
+        this.columns.splice(columns.indexOf(column), 0, column);
         shouldRedraw = true;
       }
     });

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -21,8 +21,7 @@ export type ColumnDefinition = {
   facetable_by: string[] | null;
   position?: {
     sticky: boolean;
-    side: string;
-  }
+  };
 };
 
 export type Filter = {

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -19,6 +19,10 @@ export type ColumnDefinition = {
   filterable_by: string[] | null;
   facetable: boolean;
   facetable_by: string[] | null;
+  position?: {
+    sticky: boolean;
+    side: string;
+  }
 };
 
 export type Filter = {

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/column-actions-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/column-actions-test.ts
@@ -21,7 +21,13 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/colu
     sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
       return Promise.resolve({
         columns: [
-          buildColumn('static', { type: 'text', size: FieldSize.Large, filterable: true, orderable: true }),
+          buildColumn('static', {
+            type: 'text',
+            size: FieldSize.Large,
+            filterable: true,
+            orderable: true,
+            position: { sticky: true }
+          }),
           buildColumn('Name', { type: 'text', size: FieldSize.Large, filterable: true, orderable: true })
         ]
       });
@@ -40,7 +46,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/colu
     assert.dom('.upf-btn--default').exists();
   });
 
-  test('The remove button is not displayed if it is the first column', async function (assert: Assert) {
+  test('The remove button is not displayed if it is a sticky column', async function (assert: Assert) {
     this.column = this.handler.columns[0];
     await render(
       hbs`<HyperTableV2::FilteringRenderers::Common::ColumnActions @handler={{this.handler}} @column={{this.column}} />`

--- a/tests/integration/components/hyper-table-v2/manage-columns-test.ts
+++ b/tests/integration/components/hyper-table-v2/manage-columns-test.ts
@@ -9,7 +9,7 @@ import { buildColumn, buildColumnDefinition } from '@upfluence/hypertable/test-s
 import { Column, ColumnDefinition } from '@upfluence/hypertable/core/interfaces';
 
 const COLUMN_DEFINITIONS = [
-  { key: 'alone', extra: { category: '', clustering_key: '' } },
+  { key: 'alone', extra: { category: '', clustering_key: '', position: { sticky: true } } },
   { key: 'code', extra: { category: 'affiliation', clustering_key: '' } },
   { key: 'foo', extra: { category: 'influencer', clustering_key: 'instagram' } },
   { key: 'bar', extra: { category: 'influencer', clustering_key: 'youtube' } }
@@ -24,7 +24,7 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
   setupRenderingTest(hooks);
 
   function builderHelper(
-    columnOptions: Array<{ key: string; extra: { [key: string]: string } }>,
+    columnOptions: Array<{ key: string; extra: { [key: string]: any } }>,
     buildMethod: (key: string, extra: { [key: string]: string }) => ColumnDefinition | Column
   ): (ColumnDefinition | Column)[] {
     return columnOptions.reduce((columns, column) => [...columns, ...[buildMethod(column.key, column.extra)]], []);
@@ -64,7 +64,7 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
       assert.dom('.available-fields-wrapper.visible').exists({ count: 1 });
     });
 
-    test('The first column of the table is not visible in the component', async function (assert: Assert) {
+    test('The sticky columns of the table are not visible in the component', async function (assert: Assert) {
       await render(hbs`<HyperTableV2::ManageColumns @handler={{this.handler}} />`);
 
       await click('.upf-btn.upf-btn--primary');
@@ -192,7 +192,10 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               orderable: false,
               orderable_by: [],
               size: 'M',
-              type: 'text'
+              type: 'text',
+              position: {
+                sticky: false
+              }
             },
             filters: []
           }
@@ -222,7 +225,10 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               orderable: false,
               orderable_by: [],
               size: 'M',
-              type: 'text'
+              type: 'text',
+              position: {
+                sticky: false
+              }
             },
             filters: []
           },
@@ -239,7 +245,10 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               filterable: false,
               filterable_by: [],
               facetable: false,
-              facetable_by: ['value']
+              facetable_by: ['value'],
+              position: {
+                sticky: false
+              }
             },
             filters: []
           },
@@ -256,7 +265,10 @@ module('Integration | Component | hyper-table-v2/manage-columns', function (hook
               filterable: false,
               filterable_by: [],
               facetable: false,
-              facetable_by: ['value']
+              facetable_by: ['value'],
+              position: {
+                sticky: false
+              }
             },
             filters: []
           }


### PR DESCRIPTION
### What does this PR do?

Base the column stickiness on an actual boolean on the definition instead of the column position. This allows us to handle multiple sticky columns easier.

Related to : https://github.com/upfluence/backlog/issues/1454

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
