### PR TITLE
Add a default ellipsis on the text cells depending on their size

### DIFF
--- a/addon/components/hyper-table-v2/cell-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/text.hbs
@@ -1,1 +1,7 @@
-{{or (get @row @column.definition.key) '—'}}
+{{#if this.value}}
+  <span class={{this.ellipsisClass}} {{enable-tooltip title=this.value placement="top"}}>
+    {{this.value}}
+  </span>
+{{else}}
+  —
+{{/if}}

--- a/addon/components/hyper-table-v2/cell-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/text.hbs
@@ -1,5 +1,5 @@
 {{#if this.value}}
-  <span class={{this.ellipsisClass}} {{enable-tooltip title=this.value placement="top"}}>
+  <span class="text-ellipsis" {{enable-tooltip title=this.value placement="top"}}>
     {{this.value}}
   </span>
 {{else}}

--- a/addon/components/hyper-table-v2/cell-renderers/text.ts
+++ b/addon/components/hyper-table-v2/cell-renderers/text.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
-import { Column, FieldSize, Row } from '@upfluence/hypertable/core/interfaces';
+import { Column, Row } from '@upfluence/hypertable/core/interfaces';
 
 interface HyperTableV2CellRenderersTextArgs {
   handler: TableHandler;
@@ -10,19 +10,7 @@ interface HyperTableV2CellRenderersTextArgs {
   extra?: { [key: string]: any };
 }
 
-const ELLIPSIS_STEPS: { [key: string]: string } = {
-  [FieldSize.ExtraSmall]: '100',
-  [FieldSize.Small]: '160',
-  [FieldSize.Medium]: '240',
-  [FieldSize.Large]: '340',
-  [FieldSize.ExtraLarge]: '400'
-};
-
 export default class HyperTableV2CellRenderersText extends Component<HyperTableV2CellRenderersTextArgs> {
-  get ellipsisClass(): string {
-    return `text-ellipsis-${ELLIPSIS_STEPS[this.args.column.definition.size]}`;
-  }
-
   get value(): string {
     return this.args.row[this.args.column.definition.key];
   }

--- a/addon/components/hyper-table-v2/cell-renderers/text.ts
+++ b/addon/components/hyper-table-v2/cell-renderers/text.ts
@@ -20,7 +20,6 @@ const ELLIPSIS_STEPS: { [key: string]: string } = {
 
 export default class HyperTableV2CellRenderersText extends Component<HyperTableV2CellRenderersTextArgs> {
   get ellipsisClass(): string {
-    console.log(ELLIPSIS_STEPS);
     return `text-ellipsis-${ELLIPSIS_STEPS[this.args.column.definition.size]}`;
   }
 

--- a/addon/components/hyper-table-v2/cell-renderers/text.ts
+++ b/addon/components/hyper-table-v2/cell-renderers/text.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
-import { Column, Row } from '@upfluence/hypertable/core/interfaces';
+import { Column, FieldSize, Row } from '@upfluence/hypertable/core/interfaces';
 
 interface HyperTableV2CellRenderersTextArgs {
   handler: TableHandler;
@@ -10,4 +10,21 @@ interface HyperTableV2CellRenderersTextArgs {
   extra?: { [key: string]: any };
 }
 
-export default class HyperTableV2CellRenderersText extends Component<HyperTableV2CellRenderersTextArgs> {}
+const ELLIPSIS_STEPS: { [key: string]: string } = {
+  [FieldSize.ExtraSmall]: '100',
+  [FieldSize.Small]: '160',
+  [FieldSize.Medium]: '240',
+  [FieldSize.Large]: '340',
+  [FieldSize.ExtraLarge]: '400'
+};
+
+export default class HyperTableV2CellRenderersText extends Component<HyperTableV2CellRenderersTextArgs> {
+  get ellipsisClass(): string {
+    console.log(ELLIPSIS_STEPS);
+    return `text-ellipsis-${ELLIPSIS_STEPS[this.args.column.definition.size]}`;
+  }
+
+  get value(): string {
+    return this.args.row[this.args.column.definition.key];
+  }
+}

--- a/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
@@ -4,7 +4,6 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
-import { FieldSize } from '@upfluence/hypertable/core/interfaces';
 
 module('Integration | Component | hyper-table-v2/cell-renderers/text', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
@@ -30,24 +30,4 @@ module('Integration | Component | hyper-table-v2/cell-renderers/text', function 
     assert.equal(this.row[this.column.definition.key], 'ekip');
     assert.dom('span').hasText('ekip');
   });
-
-  [
-    { size: [FieldSize.ExtraSmall], expectedEllipsisClass: 'text-ellipsis-100' },
-    { size: [FieldSize.Small], expectedEllipsisClass: 'text-ellipsis-160' },
-    { size: [FieldSize.Medium], expectedEllipsisClass: 'text-ellipsis-240' },
-    { size: [FieldSize.Large], expectedEllipsisClass: 'text-ellipsis-340' },
-    { size: [FieldSize.ExtraLarge], expectedEllipsisClass: 'text-ellipsis-400' }
-  ].forEach((testCase) => {
-    test(`it has the correct ellipsis class when column size is: ${testCase.size}`, async function (assert: Assert) {
-      this.column = this.handler.columns[0];
-      this.column.definition.size = testCase.size;
-      this.row = this.handler.rows[0];
-
-      await render(
-        hbs`<HyperTableV2::CellRenderers::Text @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
-      );
-
-      assert.dom('span').hasClass(testCase.expectedEllipsisClass);
-    });
-  });
 });

--- a/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
+import { FieldSize } from '@upfluence/hypertable/core/interfaces';
 
 module('Integration | Component | hyper-table-v2/cell-renderers/text', function (hooks) {
   setupRenderingTest(hooks);
@@ -27,6 +28,26 @@ module('Integration | Component | hyper-table-v2/cell-renderers/text', function 
 
     assert.equal(this.column.definition.key, 'foo');
     assert.equal(this.row[this.column.definition.key], 'ekip');
-    assert.dom().hasText('ekip');
+    assert.dom('span').hasText('ekip');
+  });
+
+  [
+    { size: [FieldSize.ExtraSmall], expectedEllipsisClass: 'text-ellipsis-100' },
+    { size: [FieldSize.Small], expectedEllipsisClass: 'text-ellipsis-160' },
+    { size: [FieldSize.Medium], expectedEllipsisClass: 'text-ellipsis-240' },
+    { size: [FieldSize.Large], expectedEllipsisClass: 'text-ellipsis-340' },
+    { size: [FieldSize.ExtraLarge], expectedEllipsisClass: 'text-ellipsis-400' }
+  ].forEach((testCase) => {
+    test(`it has the correct ellipsis class when column size is: ${testCase.size}`, async function (assert: Assert) {
+      this.column = this.handler.columns[0];
+      this.column.definition.size = testCase.size;
+      this.row = this.handler.rows[0];
+
+      await render(
+        hbs`<HyperTableV2::CellRenderers::Text @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
+      );
+
+      assert.dom('span').hasClass(testCase.expectedEllipsisClass);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Make sure the text cells have an ellipsis by default depending on their column's size

Related to: 
- https://github.com/upfluence/backlog/issues/1536
- https://github.com/upfluence/backlog/issues/1541

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
