### PR TITLE
core/handler: define mutateRow

### DIFF
--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -19,6 +19,8 @@ import {
 import BaseRenderingResolver from './rendering-resolver';
 import { isEmpty } from '@ember/utils';
 
+export type RowMutator = (row: Row) => boolean;
+
 export default class TableHandler {
   private _context: unknown;
   private _renderingResolver?: RendererResolver;
@@ -175,6 +177,28 @@ export default class TableHandler {
   removeRow(recordId: number): void {
     this.rows = this.rows.filter((row) => row.record_id !== recordId);
     this.triggerEvent('remove-row');
+  }
+
+  /**
+   * Updates a row by its record id.
+   *
+   * @param {number} recordId - The record id of the row
+   * @param {RowMutator} changeRow - The chagne to apply to the row, returns true if the table has to be redrawn.
+   * @returns {boolean} true if the table has been redrawn.
+   */
+  mutateRow(recordId: number, changeRow: RowMutator): boolean {
+    const shouldRefresh = this.rows
+      .filter((row: Row) => row.record_id === recordId)
+      .map(changeRow)
+      .reduce((previousValue, currentValue) => previousValue || currentValue, false);
+
+    // Triggers the redraw of the table.
+    if (shouldRefresh) {
+      this.rows = this.rows;
+      this.triggerEvent('mutate-rows');
+    }
+
+    return shouldRefresh;
   }
 
   /**

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -174,6 +174,29 @@ module('Unit | core/handler', function (hooks) {
     assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('remove-row'));
   });
 
+  test('Handler#mutateRows', async function (assert: Assert) {
+    const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+    const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
+
+    await handler.fetchRows();
+
+    let didRefresh = handler.mutateRow(12, (row: Row) :boolean => {
+      row.bar = 'woop woop'
+      return true
+    });
+
+    assert.equal(handler.rows[0].bar, 'woop woop');
+    // @ts-ignore
+    assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('mutate-rows'));
+    assert.true(didRefresh);
+
+    didRefresh = handler.mutateRow(13, () :boolean => false);
+    assert.equal(handler.rows[1].bar, 'second bar');
+    // @ts-ignore
+    assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('mutate-rows'));
+    assert.false(didRefresh);
+  });
+
   test('Handler#applyOrder', async function (assert: Assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
     const tableManagerSpy = sinon.spy(this.tableManager);


### PR DESCRIPTION
### What does this PR do?

This PR defines a way of changing a row content locally by its ID.

Related to : https://github.com/upfluence/backlog/issues/1594

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled