### PR TITLE
Fetch row after deleting a column

### DIFF
--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -157,14 +157,17 @@ export default class TableHandler {
    * @returns {Promise<void>}
    */
   async removeColumn(definition: ColumnDefinition): Promise<void> {
+    const columnToRemove = this.columns.filter((column) => column.definition.key === definition.key);
     return this.tableManager
       .upsertColumns({
         columns: this.columns.filter((column) => column.definition.key !== definition.key)
       })
       .then(({ columns }) => {
         this.columns = columns;
-        this._reinitColumnsAndRows(columns);
-        this.triggerEvent('remove-column');
+        if (columnToRemove.length > 0 && columnToRemove[0].filters.length > 0) {
+          this._reinitColumnsAndRows(columns);
+          this.triggerEvent('remove-column');
+        }
       });
   }
 

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -161,8 +161,10 @@ export default class TableHandler {
       .upsertColumns({
         columns: this.columns.filter((column) => column.definition.key !== definition.key)
       })
-      .then((resp) => {
-        this.columns = resp.columns;
+      .then(({ columns }) => {
+        this.columns = columns;
+        this._reinitColumnsAndRows(columns);
+        this.triggerEvent('remove-column');
       });
   }
 
@@ -358,25 +360,20 @@ export default class TableHandler {
   }
 
   private _reinitColumnsAndRows(columns: Column[]): void {
-    this.rows = [];
-
     let shouldRedraw = false;
-
     columns.forEach((column) => {
       let existingColumn = this.columns.find((c) => c.definition.key === column.definition.key);
 
-      if (existingColumn) {
-        existingColumn = column;
-      } else {
+      if (!existingColumn) {
         this.columns.splice(columns.indexOf(column), 0, column);
         shouldRedraw = true;
       }
     });
-
     if (shouldRedraw) {
       this.columns = this.columns;
     }
 
+    this.rows = [];
     this.currentPage = 1;
     this.fetchRows();
   }

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -62,34 +62,66 @@ module('Unit | core/handler', function (hooks) {
     assert.equal(handler.columns[0].definition.key, 'foo');
   });
 
-  test('Handler#removeColumn', async function (assert: Assert) {
-    const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
-    const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
-    handler.columns = [
-      {
-        definition: {
-          key: 'foo',
-          type: 'text',
-          name: `foo`,
-          clustering_key: '',
-          category: '',
-          size: FieldSize.Medium,
-          orderable: false,
-          orderable_by: [],
-          filterable: false,
-          filterable_by: [],
-          facetable: false,
-          facetable_by: ['value']
-        },
-        filters: []
-      }
-    ];
+  module('Handler#removeColumn', function () {
+    test('when filter is empty', async function (assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
+      handler.columns = [
+        {
+          definition: {
+            key: 'foo',
+            type: 'text',
+            name: `foo`,
+            clustering_key: '',
+            category: '',
+            size: FieldSize.Medium,
+            orderable: false,
+            orderable_by: [],
+            filterable: false,
+            filterable_by: [],
+            facetable: false,
+            facetable_by: ['value']
+          },
+          filters: []
+        }
+      ];
 
-    assert.equal(handler.columns.length, 1);
-    await handler.removeColumn(handler.columns[0].definition);
-    assert.equal(handler.columns.length, 0);
-    // @ts-ignore
-    assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('remove-column'));
+      assert.equal(handler.columns.length, 1);
+      await handler.removeColumn(handler.columns[0].definition);
+      assert.equal(handler.columns.length, 0);
+      // @ts-ignore
+      assert.ok(handlerTriggerEventSpy.notCalled);
+    });
+
+    test('when filters is present', async function (assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
+      handler.columns = [
+        {
+          definition: {
+            key: 'foo',
+            type: 'text',
+            name: `foo`,
+            clustering_key: '',
+            category: '',
+            size: FieldSize.Medium,
+            orderable: false,
+            orderable_by: [],
+            filterable: false,
+            filterable_by: [],
+            facetable: false,
+            facetable_by: ['value']
+          },
+          filters: [{ key: 'value', value: '3' }]
+        }
+      ];
+
+      assert.equal(handler.columns.length, 1);
+      await handler.removeColumn(handler.columns[0].definition);
+      assert.equal(handler.columns.length, 0);
+      // @ts-ignore
+      assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('remove-column'));
+    });
   });
 
   module('Handler#applyFilter', function (hooks) {

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -64,6 +64,7 @@ module('Unit | core/handler', function (hooks) {
 
   test('Handler#removeColumn', async function (assert: Assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+    const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
     handler.columns = [
       {
         definition: {
@@ -87,6 +88,8 @@ module('Unit | core/handler', function (hooks) {
     assert.equal(handler.columns.length, 1);
     await handler.removeColumn(handler.columns[0].definition);
     assert.equal(handler.columns.length, 0);
+    // @ts-ignore
+    assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('remove-column'));
   });
 
   module('Handler#applyFilter', function (hooks) {


### PR DESCRIPTION
### What does this PR do?

Add refresh of rows for `removeColumn` and trigger `remove-column` event

Related to : https://github.com/upfluence/backlog/issues/1525

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
