### PR TITLE
Prevent users from applying multiple facets at once on fast clicks

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
@@ -22,9 +22,15 @@
       <div class="fx-row fx-malign-space-between fx-xalign-center padding-xxx-sm"
            role="button" {{on "click" (fn this.toggleFacet facet)}}>
         <div class="fx-row item">
-          <OSS::Checkbox
-            @checked={{array-includes this.appliedFacets facet.identifier}} @size="sm" @onChange={{fn this.toggleFacet facet}}
-            class="margin-right-xx-sm" />
+          {{#if this.ongoingFacetApply}}
+            <span class="margin-right-xx-sm">
+              <i class="fa fa-circle-o-notch fa-spin"></i>
+            </span>
+          {{else}}
+            <OSS::Checkbox
+              @checked={{array-includes this.appliedFacets facet.identifier}} @size="sm" @onChange={{fn this.toggleFacet facet}}
+              class="margin-right-xx-sm" />
+          {{/if}}
           {{yield (hash appliedFacets=this.appliedFacets facet=facet) to="facet-item"}}
         </div>
 

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -15,6 +15,7 @@ interface FacetsLoaderArgs {
 }
 
 const SEARCH_DEBOUNCE_TIME: number = 300;
+const FACET_APPLY_DEBOUNCE_TIME: number = 300;
 
 export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs> {
   @tracked loading = false;
@@ -65,7 +66,7 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
       this,
       this.appliedFacets.includes(facet.identifier) ? this.removeFacet : this.addFacet,
       facet,
-      300
+      FACET_APPLY_DEBOUNCE_TIME
     );
   }
 
@@ -89,7 +90,6 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
   }
 
   private removeFacet(facet: Facet): void {
-    console.log(facet);
     const existingFilter = this.args.column.filters.find((filter) => filter.key === this.filteringKey);
 
     if (existingFilter) {


### PR DESCRIPTION
### What does this PR do?

Prevent users from applying multiple facets at once on fast clicks

Related to : https://github.com/upfluence/backlog/issues/1526

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
