### PR TITLE
Remove upf-btn--small classes

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/column-actions.hbs
@@ -1,10 +1,10 @@
 <div class="fx-row fx-malign-space-between">
   {{#if this.shouldDisplay}}
-    <OSS::Button @skin="destructive" @size="sm" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
+    <OSS::Button @skin="destructive" @label={{t "hypertable.column.remove"}} {{on "click" this.removeColumn}}
                  data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_remove_column"}} />
   {{else}}
     <div class="fx-1"></div>
   {{/if}}
-  <OSS::Button @size="sm" @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
+  <OSS::Button @label={{t "hypertable.column.clear_filters"}} {{on "click" this.reset}}
                data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_clear_filters"}} />
 </div>

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -120,7 +120,7 @@
       </div>
 
       <div class="scroll-button-container {{if this.scrollableTable 'is-visible'}}">
-        <OSS::Button @size="sm" @icon="fa fa-chevron-right" class="scroll-button is-visible"
+        <OSS::Button @icon="fa fa-chevron-right" class="scroll-button is-visible"
                      {{on "click" this.scrollToEnd}} />
       </div>
     {{/if}}

--- a/addon/components/hyper-table/cell-renderers/link.hbs
+++ b/addon/components/hyper-table/cell-renderers/link.hbs
@@ -3,25 +3,17 @@
 {{else}}
   <a
     href={{this.value}}
-    target='_blank'
-    rel='noopener'
-    class='upf-link--reset link__value'
-    onclick='event.stopPropagation();'
+    target="_blank"
+    rel="noopener"
+    class="upf-link--reset link__value"
+    onclick="event.stopPropagation();"
   >
     {{value}}
   </a>
 
-  {{#if isCopied}}
-    <i
-      class='link__copy upf-btn fa fa-copy success-tooltip'
-      {{action 'copy' bubbles=false}}
-      {{enable-tooltip title='Copied' placement='top'}}
-    ></i>
-  {{else}}
-    <i
-      class='link__copy upf-btn fa fa-copy'
-      {{action 'copy' bubbles=false}}
-      {{enable-tooltip title='Copy' placement='top'}}
-    ></i>
-  {{/if}}
+  <OSS::Button
+    @icon="fa fa-copy"
+    class="link__copy {{if this.isCopied 'success-tooltip'}}"
+    {{enable-tooltip title=(if this.isCopied "Copied" "Copy") placement="top"}}
+    {{action "copy" bubbles=false}} />
 {{/if}}

--- a/addon/components/hyper-table/filters-renderers/date.hbs
+++ b/addon/components/hyper-table/filters-renderers/date.hbs
@@ -40,13 +40,9 @@
     </div>
   </div>
 
-  <div class="margin-top-xx-sm buttons-container">
-    <button class="upf-btn upf-btn--destructive upf-btn--small" type="button" {{on "click" this.removeColumn}}>
-      {{t "hypertable.column.remove"}}
-    </button>
-
-    <button class="upf-btn upf-btn--default upf-btn--small" type="button" {{on "click" this.reset}}>
-      {{t "hypertable.column.filtering.clear"}}
-    </button>
+  <div class="margin-top-px-12 fx-row fx-malign-space-between">
+    <OSS::Button
+      @skin="destructive" @label="Remove field" {{on "click" this.removeColumn}} />
+    <OSS::Button @label="Clear filters" {{on "click" this.reset}} />
   </div>
 {{/if}}

--- a/addon/components/hyper-table/filters-renderers/money.hbs
+++ b/addon/components/hyper-table/filters-renderers/money.hbs
@@ -1,14 +1,14 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Order By</label>
-    <div class='btn-group upf-radio-group' data-control-name={{concat _controlNamePrefix '_order_by_radio'}}>
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_order_by_radio"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value
           currentValue=column.orderBy
           label=label
           options=orderingOptions
-          onCheck='orderingOptionChanged'
+          onCheck="orderingOptionChanged"
         }}
       {{/each-in}}
     </div>
@@ -16,11 +16,11 @@
 {{/if}}
 
 {{#if column.filterable}}
-  {{#input-wrapper classNames=(if column.orderable 'margin-top-xx-sm')}}
+  {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Display</label>
     <div
-      class='btn-group upf-radio-group upf-radio-group--block'
-      data-control-name={{concat _controlNamePrefix '_filter_by_radio'}}
+      class="btn-group upf-radio-group upf-radio-group--block"
+      data-control-name={{concat _controlNamePrefix "_filter_by_radio"}}
     >
       {{#each-in existenceFilters as |label value|}}
         {{radio-button
@@ -28,36 +28,32 @@
           currentValue=currentExistenceFilter
           label=label
           options=existenceFilters
-          onCheck='existenceFilterChanged'
+          onCheck="existenceFilterChanged"
         }}
       {{/each-in}}
     </div>
   {{/input-wrapper}}
 
-  <div class='row' data-control-name={{concat _controlNamePrefix '_range_inputs'}}>
-    {{#input-wrapper classNames='col-xs-6'}}
+  <div class="row" data-control-name={{concat _controlNamePrefix "_range_inputs"}}>
+    {{#input-wrapper classNames="col-xs-6"}}
       <label>From</label>
       {{input
-        type='number'
-        placeholder='From'
+        type="number"
+        placeholder="From"
         value=lowerBoundFilter
-        class='form-control upf-input upf-input--textarea'
+        class="form-control upf-input upf-input--textarea"
       }}
     {{/input-wrapper}}
 
-    {{#input-wrapper classNames='col-xs-6'}}
+    {{#input-wrapper classNames="col-xs-6"}}
       <label>To</label>
-      {{input type='number' placeholder='To' value=upperBoundFilter class='form-control upf-input upf-input--textarea'}}
+      {{input type="number" placeholder="To" value=upperBoundFilter class="form-control upf-input upf-input--textarea"}}
     {{/input-wrapper}}
   </div>
 
-  <div class='margin-top-xx-sm buttons-container'>
-    <button class='upf-btn upf-btn--destructive upf-btn--small' {{action 'removeColumn'}}>
-      Remove Field
-    </button>
-
-    <button class='upf-btn upf-btn--default upf-btn--small' {{action 'reset'}}>
-      Clear Filters
-    </button>
+  <div class="margin-top-px-12 fx-row fx-malign-space-between">
+    <OSS::Button
+      @skin="destructive" @label="Remove field" {{action "removeColumn"}} />
+    <OSS::Button @label="Clear filters" {{action "reset"}} />
   </div>
 {{/if}}

--- a/addon/components/hyper-table/filters-renderers/numeric.hbs
+++ b/addon/components/hyper-table/filters-renderers/numeric.hbs
@@ -1,14 +1,14 @@
 {{#if column.orderable}}
   {{#input-wrapper}}
     <label>Order By</label>
-    <div class='btn-group upf-radio-group' data-control-name={{concat _controlNamePrefix '_order_by_radiogroup'}}>
+    <div class="btn-group upf-radio-group" data-control-name={{concat _controlNamePrefix "_order_by_radiogroup"}}>
       {{#each-in orderingOptions as |label value|}}
         {{radio-button
           value=value
           currentValue=column.orderBy
           label=label
           options=orderingOptions
-          onCheck='orderingOptionChanged'
+          onCheck="orderingOptionChanged"
         }}
       {{/each-in}}
     </div>
@@ -16,11 +16,11 @@
 {{/if}}
 
 {{#if column.filterable}}
-  {{#input-wrapper classNames=(if column.orderable 'margin-top-xx-sm')}}
+  {{#input-wrapper classNames=(if column.orderable "margin-top-xx-sm")}}
     <label>Display</label>
     <div
-      class='btn-group upf-radio-group upf-radio-group--block'
-      data-control-name={{concat _controlNamePrefix '_display_radiogroup'}}
+      class="btn-group upf-radio-group upf-radio-group--block"
+      data-control-name={{concat _controlNamePrefix "_display_radiogroup"}}
     >
       {{#each-in existenceFilters as |label value|}}
         {{radio-button
@@ -28,36 +28,32 @@
           currentValue=currentExistenceFilter
           label=label
           options=existenceFilters
-          onCheck='existenceFilterChanged'
+          onCheck="existenceFilterChanged"
         }}
       {{/each-in}}
     </div>
   {{/input-wrapper}}
 
-  <div class='row margin-top-xx-sm' data-control-name={{concat _controlNamePrefix '_range_radiogroup'}}>
-    {{#input-wrapper classNames='col-xs-6'}}
+  <div class="row margin-top-xx-sm" data-control-name={{concat _controlNamePrefix "_range_radiogroup"}}>
+    {{#input-wrapper classNames="col-xs-6"}}
       <label>From</label>
       {{input
-        type='number'
-        placeholder='From'
+        type="number"
+        placeholder="From"
         value=lowerBoundFilter
-        class='form-control upf-input upf-input--textarea'
+        class="form-control upf-input upf-input--textarea"
       }}
     {{/input-wrapper}}
 
-    {{#input-wrapper classNames='col-xs-6'}}
+    {{#input-wrapper classNames="col-xs-6"}}
       <label>To</label>
-      {{input type='number' placeholder='To' value=upperBoundFilter class='form-control upf-input upf-input--textarea'}}
+      {{input type="number" placeholder="To" value=upperBoundFilter class="form-control upf-input upf-input--textarea"}}
     {{/input-wrapper}}
   </div>
 
-  <div class='margin-top-xx-sm buttons-container'>
-    <button class='upf-btn upf-btn--destructive upf-btn--small' {{action 'removeColumn'}}>
-      Remove Field
-    </button>
-
-    <button class='upf-btn upf-btn--default upf-btn--small' {{action 'reset'}}>
-      Clear Filters
-    </button>
+  <div class="margin-top-px-12 fx-row fx-malign-space-between">
+    <OSS::Button
+      @skin="destructive" @label="Remove field" {{action "removeColumn"}} />
+    <OSS::Button @label="Clear filters" {{action "reset"}} />
   </div>
 {{/if}}

--- a/addon/components/hyper-table/filters-renderers/text.hbs
+++ b/addon/components/hyper-table/filters-renderers/text.hbs
@@ -47,13 +47,9 @@
     </div>
   {{/input-wrapper}}
 
-  <div class='margin-top-xx-sm buttons-container'>
-    <button class='upf-btn upf-btn--destructive upf-btn--small' {{action 'removeColumn'}}>
-      Remove Field
-    </button>
-
-    <button class='upf-btn upf-btn--default upf-btn--small' {{action 'reset'}}>
-      Clear Filters
-    </button>
+  <div class="margin-top-px-12 fx-row fx-malign-space-between">
+    <OSS::Button
+      @skin="destructive" @label="Remove field" {{action "removeColumn"}} />
+    <OSS::Button @label="Clear filters" {{action "reset"}} />
   </div>
 {{/if}}

--- a/addon/components/hyper-table/index.hbs
+++ b/addon/components/hyper-table/index.hbs
@@ -32,27 +32,29 @@
 
   <div class="right-side">
     {{#if this.manager.options.features.filtering}}
-      <button
-        class="margin-right-xx-sm margin-bottom-xxx-sm upf-btn upf-btn--default upf-btn--small"
-        data-control-name="table_reset_filters" {{action "resetAllFilters"}}
-        type="button">
-        {{t "hypertable.features.filtering.reset_all"}}
-      </button>
+      <OSS::Button
+        @label={{t "hypertable.features.filtering.reset_all"}}
+        class="margin-right-px-12 margin-bottom-px-6"
+        data-control-name="table_reset_filters"
+        {{action "resetAllFilters"}} />
     {{/if}}
 
     {{#if this.manager.options.features.tableViews}}
-      <button
-        class="margin-right-xx-sm margin-bottom-xxx-sm upf-btn upf-btn--default upf-btn--small views-manager-toggle icon-responsive"
-        data-control-name="table_toggle_views" type="button" {{action "openAvailableViews" bubbles=false}}>
-        <i class="fa fa-eye margin-right-xxx-sm"></i> {{t "hypertable.features.table_views.title"}}
-      </button>
+      <OSS::Button
+        @icon="fa fa-eye"
+        @label={{t "hypertable.features.table_views.title"}}
+        class="margin-right-px-12 margin-bottom-px-6 views-manager-toggle icon-responsive"
+        data-control-name="table_toggle_views"
+        {{action "openAvailableViews" bubbles=false}} />
     {{/if}}
 
-    <button
-      class="margin-bottom-xxx-sm upf-btn upf-btn--primary upf-btn--small fields-manager-toggle icon-responsive"
-      data-control-name="table_toggle_fields" type="button" {{action "openAvailableFields" bubbles=false}}>
-      <i class="fa fa-columns margin-right-xxx-sm"></i> {{t "hypertable.features.manage_fields.title"}}
-    </button>
+    <OSS::Button
+      @skin="primary"
+      @icon="fa fa-columns"
+      @label={{t "hypertable.features.manage_fields.title"}}
+      class="margin-bottom-px-6 fields-manager-toggle icon-responsive"
+      data-control-name="table_toggle_fields"
+      {{action "openAvailableFields" bubbles=false}} />
 
     <HyperTable::Views
       @manager={{this.manager}} @closeAvailableViews={{action "closeAvailableViews"}} />
@@ -236,11 +238,10 @@
   </div>
 
   <div class="scroll-button-container {{if this.manager.isScrollable 'is-visible'}}">
-    <button
-      class="upf-btn upf-btn--small scroll-button {{if this.manager.isScrollable 'is-visible'}}"
-      {{action "scrollToEnd"}} type="button">
-      {{t "hypertable.column.scroll_to_end"}} <i class='fa fa-chevron-right margin-left-xxx-sm'></i>
-    </button>
+    <OSS::Button
+      @label={{t "hypertable.column.scroll_to_end"}}
+      class="scroll-button {{if this.manager.isScrollable 'is-visible'}}"
+      {{action "scrollToEnd"}} />
   </div>
 </div>
 

--- a/addon/components/hyper-table/views.hbs
+++ b/addon/components/hyper-table/views.hbs
@@ -19,7 +19,7 @@
                                @selectedView={{this.selectedView}} @onSelectView={{action "selectView"}} />
     {{/each}}
   </div>
-  <OSS::Button class="margin-top-x-sm padding-xxx-sm" @skin="primary" @icon="fas fa-plus" @label={{t "hypertable.view.add"}} @size="sm"
+  <OSS::Button class="margin-top-x-sm" @skin="primary" @icon="fas fa-plus" @label={{t "hypertable.view.add"}} 
                {{on "click" (action "toggleAddViewModal" bubbles=false)}} />
 </div>
 

--- a/app/styles/cells.less
+++ b/app/styles/cells.less
@@ -246,19 +246,6 @@
     white-space: nowrap;
   }
 
-  .link__copy {
-    position: relative;
-    display: flex;
-    align-items: center;
-    background-color: @upf-gray-light;
-    height: 30px;
-    padding: @spacing-xxx-sm;
-
-    &:hover {
-      background-color: @upf-gray;
-    }
-  }
-
   .upf-icon--check {
     background-color: white;
     animation: fadeIn 1.5s ease forwards;

--- a/app/styles/columns.less
+++ b/app/styles/columns.less
@@ -365,9 +365,4 @@
       overflow: auto;
     }
   }
-
-  .buttons-container {
-    display: flex;
-    justify-content: space-between;
-  }
 }


### PR DESCRIPTION
### What does this PR do?

Remove upf-btn--small classes or usages of `size="sm"` OSS::Button 

Related to : https://github.com/upfluence/backlog/issues/1705

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
