### PR TITLE
Destroy column filter when it is open in v1

### DIFF
--- a/addon/components/hyper-table/column.js
+++ b/addon/components/hyper-table/column.js
@@ -63,6 +63,12 @@ export default Component.extend({
     }
   },
 
+  willDestroyElement() {
+    if (this.manager.tetherOn !== this.column.key) {
+      this.manager.destroyTetherInstance();
+    }
+  },
+
   actions: {
     toggleFiltersPanel() {
       let isFirstColumn = this.manager.columns.indexOf(this.column) === 1;


### PR DESCRIPTION
### What does this PR do?

Destroy column filter when it is open in v1

Related to : https://github.com/upfluence/backlog/issues/1893

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
