### PR TITLE
Hypertable v2 support new selection

### DIFF
--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -1,4 +1,4 @@
 import TableManager from './table-manager';
-import RowsFetcher from './rows-fetcher';
+import RowsFetcher, { AllRowsFetcher } from './rows-fetcher';
 
-export { TableManager, RowsFetcher };
+export { TableManager, RowsFetcher, AllRowsFetcher };

--- a/addon-test-support/rows-fetcher.ts
+++ b/addon-test-support/rows-fetcher.ts
@@ -32,3 +32,36 @@ export default class RowsFetcher {
     });
   }
 }
+
+export class AllRowsFetcher {
+  // @ts-ignore
+  fetch(page: number, perPage: number): Promise<RowsFetcherResponse> {
+    return Promise.resolve({
+      rows: [
+        {
+          influencerId: 42,
+          recordId: 12,
+          record_id: 12,
+          holderId: 57,
+          holderType: 'list',
+          foo: 'ekip',
+          bar: 'hello',
+          total: 123,
+          date: 1643386394
+        },
+        {
+          influencerId: 43,
+          recordId: 13,
+          record_id: 13,
+          holderId: 57,
+          holderType: 'list',
+          foo: 'second',
+          bar: 'second bar',
+          total: 123123,
+          date: 0
+        }
+      ],
+      meta: { total: 2 }
+    });
+  }
+}

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -1,31 +1,36 @@
 <div class="hypertable-container" ...attributes>
-  <div class="hypertable__upper-header fx-row">
-    <div class="left-side padding-left-xx-sm">
-      {{#if this.features.selection}}
-        <div class="selected-count">
-          {{format-number this.selectionCount}}
-        </div>
-      {{/if}}
+  <div class="hypertable__upper-header">
+    <div class="fx-row">
+      <div class="left-side">
+        {{#if this.features.selection}}
+          <div class="selected-count">
+            {{format-number this.selectionCount}}
+          </div>
+        {{/if}}
 
-      {{#if this.initialFetchColumnsDone}}
-        <div class="search">
-          {{#if (has-block "search")}}
-            {{yield to="search"}}
-          {{else if this.features.searchable}}
-            <HyperTableV2::Search @handler={{@handler}} />
-          {{/if}}
-        </div>
-      {{/if}}
-      {{#if (has-block "contextual-actions")}}
-        {{yield to="contextual-actions"}}
-      {{/if}}
+        {{#if this.initialFetchColumnsDone}}
+          <div class="search">
+            {{#if (has-block "search")}}
+              {{yield to="search"}}
+            {{else if this.features.searchable}}
+              <HyperTableV2::Search @handler={{@handler}} />
+            {{/if}}
+          </div>
+        {{/if}}
+        {{#if (has-block "contextual-actions")}}
+          {{yield to="contextual-actions"}}
+        {{/if}}
+      </div>
+      <div class="right-side">
+        <OSS::Button class="margin-right-xx-sm" @label={{t "hypertable.features.filtering.reset_all"}}
+          {{on "click" this.resetFilters}} @loading={{this.loadingResetFilters}}
+                     data-control-name="hypertable_reset_filters_button" />
+        <HyperTableV2::ManageColumns @handler={{@handler}} @didInsertColumn={{this.scrollToEnd}} />
+      </div>
     </div>
-    <div class="right-side">
-      <OSS::Button class="margin-right-xx-sm" @label={{t "hypertable.features.filtering.reset_all"}}
-                   {{on "click" this.resetFilters}} @loading={{this.loadingResetFilters}}
-                   data-control-name="hypertable_reset_filters_button" />
-      <HyperTableV2::ManageColumns @handler={{@handler}} @didInsertColumn={{this.scrollToEnd}} />
-    </div>
+    <HyperTableV2::Selection class={{if (gt selectionCount 0) "margin-top-px-18"}} @selected={{this.selectionCount}}
+                             @total={{@handler.rowsMeta.total}} @onSelectAll={{this.selectAllGlobal}}
+                             @onClear={{this.clearSelection}} />
   </div>
 
   <div class="hypertable__table hypertable__table--v2" {{did-insert this.setupInnerTableElement}}>
@@ -62,17 +67,15 @@
               {{#if this.features.selection}}
                 <div class="hypertable__column hypertable__column--selection">
                   <header>
-                    <OSS::Checkbox @checked={{eq @handler.selection "all"}} @size="sm"
-                                   @onChange={{this.toggleSelectAll}}
-                                   @disabled={{false}} />
+                    <OSS::Checkbox @checked={{gt this.selectionCount 0}} @size="sm" @onChange={{this.toggleSelectAll}}
+                                   @partial={{lt this.selectionCount @handler.rowsMeta.total}} />
                   </header>
 
                   {{#each @handler.rows as |row|}}
                     <HyperTableV2::Cell @handler={{@handler}} @column={{column}} @row={{row}}
                                         @onClick={{this.onRowClick}} @onHover={{this.onRowHover}}>
-                      <OSS::Checkbox @checked={{or (array-includes @handler.selection row) (eq @handler.selection "all")}}
-                                     @size="sm" @onChange={{fn this.toggleRowSelection row}}
-                                     @disabled={{eq @handler.selection "all"}} />
+                      <OSS::Checkbox @checked={{if (eq @handler.selection "all") (not (array-includes @handler.exclusion row)) (array-includes @handler.selection row)}}
+                                     @size="sm" @onChange={{fn this.toggleRowSelection row}} />
                     </HyperTableV2::Cell>
                   {{/each}}
 

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -23,7 +23,7 @@
       </div>
       <div class="right-side">
         <OSS::Button class="margin-right-xx-sm" @label={{t "hypertable.features.filtering.reset_all"}}
-          {{on "click" this.resetFilters}} @loading={{this.loadingResetFilters}}
+                     {{on "click" this.resetFilters}} @loading={{this.loadingResetFilters}}
                      data-control-name="hypertable_reset_filters_button" />
         <HyperTableV2::ManageColumns @handler={{@handler}} @didInsertColumn={{this.scrollToEnd}} />
       </div>

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -50,7 +50,7 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     }
 
     if (this.args.handler.selection === 'all') {
-      return this.args.handler.rowsMeta.total;
+      return this.args.handler.rowsMeta.total - this.args.handler.exclusion.length;
     } else {
       return this.args.handler.selection.length;
     }
@@ -110,8 +110,22 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   }
 
   @action
+  selectAllGlobal() {
+    this.args.handler.selectAllGlobal();
+  }
+
+  @action
+  clearSelection() {
+    this.args.handler.clearSelection();
+  }
+
+  @action
   toggleRowSelection(row: Row): void {
-    this.args.handler.updateSelection(row);
+    if (this.args.handler.selection === 'all') {
+      this.args.handler.updateExclusion(row);
+    } else {
+      this.args.handler.updateSelection(row);
+    }
   }
 
   @action

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -100,22 +100,22 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   }
 
   @action
-  resetFilters() {
+  resetFilters(): void {
     debounce(this, this._resetFilters, RESET_DEBOUNCE_TIME);
   }
 
   @action
-  toggleSelectAll(value: boolean) {
+  toggleSelectAll(value: boolean): void {
     this.args.handler.toggleSelectAll(value);
   }
 
   @action
-  selectAllGlobal() {
+  selectAllGlobal(): void {
     this.args.handler.selectAllGlobal();
   }
 
   @action
-  clearSelection() {
+  clearSelection(): void {
     this.args.handler.clearSelection();
   }
 
@@ -140,17 +140,17 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   }
 
   @action
-  onRowClick(row: Row) {
+  onRowClick(row: Row): void {
     this.args.handler.triggerEvent('row-click', row);
   }
 
   @action
-  onRowHover(row: Row, hovered: boolean) {
+  onRowHover(row: Row, hovered: boolean): void {
     set(this.args.handler.rows[this.args.handler.rows.indexOf(row)], 'hovered', hovered);
   }
 
   @action
-  reloadPage() {
+  reloadPage(): void {
     window.location.reload();
   }
 

--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -293,8 +293,8 @@ export default Component.extend({
       this.set('_selectAllChecked', false);
     },
 
-    toggleSelectAll() {
-      this.set('_selectAllChecked', !this._selectAllChecked);
+    toggleSelectAll(value) {
+      this.set('_selectAllChecked', value);
       if (this._selectAllChecked) {
         if (this._selectedCount === this.meta.total) {
           this._allRowSelectedManager(true);
@@ -306,8 +306,8 @@ export default Component.extend({
       }
     },
 
-    toggleItem(item) {
-      item.set('selected', !item.selected);
+    toggleItem(item, value) {
+      item.set('selected', value);
       this.set('_selectAllChecked', this._selectedCount > 0);
 
       if (this._allRowsSelected) {

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -35,6 +35,7 @@ export default class TableHandler {
   @tracked columns: Column[] = [];
   @tracked rows: Row[] = [];
   @tracked selection: Row[] | 'all' = [];
+  @tracked exclusion: Row[] = [];
 
   @tracked loadingColumns: boolean = true;
   @tracked loadingRows: boolean = true;
@@ -316,12 +317,40 @@ export default class TableHandler {
   }
 
   /**
-   * Toggle the selection state of all rows.
+   * Toggle the selection state of loaded or all rows.
    *
    * @param {boolean} toggled
    */
   toggleSelectAll(toggled: boolean): void {
-    this.selection = toggled ? 'all' : [];
+    if (toggled) {
+      if (this.rowsMeta?.total === this.rows.length) {
+        this.selection = 'all';
+      } else {
+        this.selection = this.rows;
+      }
+    } else {
+      this.clearSelection();
+    }
+  }
+
+  /**
+   * Update the selection state of all row and clean exclusion rows array
+   *
+   * @returns {void}
+   */
+  selectAllGlobal(): void {
+    this.selection = 'all';
+    this.exclusion = [];
+  }
+
+  /**
+   * Clean selection and exclusion rows arrays
+   *
+   * @returns {void}
+   */
+  clearSelection(): void {
+    this.selection = [];
+    this.exclusion = [];
   }
 
   /**
@@ -333,9 +362,25 @@ export default class TableHandler {
     this.selection = this.selection instanceof Array ? this.selection : [];
 
     if (this.selection.includes(row)) {
-      this.selection = this.selection.filter((_selectedRow: Row) => _selectedRow !== row);
+      this.selection = this.selection.filter((selectedRow: Row) => selectedRow !== row);
     } else {
-      this.selection = [...this.selection, ...[row]];
+      this.selection = [...this.selection, row];
+      if (this.selection.length === this.rowsMeta?.total) {
+        this.selection = 'all';
+      }
+    }
+  }
+
+  /**
+   * Add or remove a row to the excluded items depending on whether it's already present or not.
+   *
+   * @param {Row} row
+   */
+  updateExclusion(row: Row): void {
+    if (this.exclusion.includes(row)) {
+      this.exclusion = this.exclusion.filter((excludedRow: Row) => excludedRow !== row);
+    } else {
+      this.exclusion = [...this.exclusion, row];
     }
   }
 

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -317,7 +317,7 @@ export default class TableHandler {
   }
 
   /**
-   * Toggle the selection state of loaded or all rows.
+   * Toggle the selection state between loaded and all rows.
    *
    * @param {boolean} toggled
    */
@@ -334,7 +334,7 @@ export default class TableHandler {
   }
 
   /**
-   * Update the selection state of all row and clean exclusion rows array
+   * Update the selection state of all rows and clean exclusion rows array
    *
    * @returns {void}
    */

--- a/app/styles/columns.less
+++ b/app/styles/columns.less
@@ -2,7 +2,6 @@
   opacity: 1;
   transition: all 0.125s;
   height: fit-content;
-  border-top: 1px solid var(--color-border-default);
 
   &--size-XS {
     min-width: 125px;

--- a/app/styles/inner-table.less
+++ b/app/styles/inner-table.less
@@ -4,7 +4,6 @@
 
 .hypertable__table {
   border: 1px solid var(--color-border-default);
-  border-top: none;
   border-radius: var(--border-radius-md);
   height: 700px;
   overflow: auto;

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -164,8 +164,8 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('.selected-count').exists();
     });
 
-    module('when clicking the checkbox in the header of the selection column with partial rows loaded', () => {
-      test('it triggers the handler SelectAll', async function (assert: Assert) {
+    module('when clicking on the select-all checkbox with partial rows loaded', () => {
+      test('it triggers the handler SelectAll function', async function (assert: Assert) {
         const toggleSelectAllStub = sinon.stub(this.handler, 'toggleSelectAll');
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
@@ -182,7 +182,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
         assert.dom('.selected-count').hasText(this.handler.selection.length.toString());
       });
 
-      test('it renders the partial mode for the head checkbox', async function (assert: Assert) {
+      test('it renders the partial mode for the select-all checkbox', async function (assert: Assert) {
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
 
@@ -206,13 +206,13 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
     });
 
-    module('when clicking the checkbox in the header of the selection column with all rows loaded', (hooks) => {
+    module('when clicking on the select-all checkbox all rows loaded', (hooks) => {
       hooks.beforeEach(function () {
         this.rowsFetcher = new AllRowsFetcher();
         this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
       });
 
-      test('it triggers the handler SelectAll', async function (assert: Assert) {
+      test('it triggers the handler SelectAll function', async function (assert: Assert) {
         const toggleSelectAllStub = sinon.stub(this.handler, 'toggleSelectAll');
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
@@ -229,7 +229,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
         assert.dom('.selected-count').hasText(this.handler.rowsMeta.total.toString());
       });
 
-      test('it renders the checked mode for the head checkbox', async function (assert: Assert) {
+      test('it renders the checked mode for the select-all checkbox', async function (assert: Assert) {
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
 
@@ -252,7 +252,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
     });
 
-    module('when header checkbox is check with partial select all', () => {
+    module('when the select-all checkbox is partially selected', () => {
       test('all checkboxes of loaded rows are selected', async function (assert: Assert) {
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
@@ -300,7 +300,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
     });
 
-    module('when header checkbox is check with global select all', () => {
+    module('when the select-all checkbox is globally selected', () => {
       test('all checkboxes of loaded rows are selected', async function (assert: Assert) {
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
@@ -346,7 +346,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
     });
 
-    test('clicking a row selection checkbox toggles its selection status', async function (assert: Assert) {
+    test('clicking a one multiline checkbox toggles its selection status', async function (assert: Assert) {
       const handlerSpy = sinon.spy(this.handler);
       await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
@@ -372,7 +372,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('.selected-count').hasText('0');
     });
 
-    test('clicking on all row selection checkbox toggles the select all', async function (assert: Assert) {
+    test('clicking on all multiline checkbox toggles the global select', async function (assert: Assert) {
       this.rowsFetcher = new AllRowsFetcher();
       this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
       const handlerSpy = sinon.spy(this.handler);
@@ -392,7 +392,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.equal(this.handler.selection, 'all');
     });
 
-    test('clicking a row selection checkbox toggles its exclusion status', async function (assert: Assert) {
+    test('clicking on one multiline checkbox toggles its exclusion status', async function (assert: Assert) {
       const handlerSpy = sinon.spy(this.handler);
       await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, findAll, render } from '@ember/test-helpers';
+import { click, render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
-import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
+import { TableManager, RowsFetcher, AllRowsFetcher } from '@upfluence/hypertable/test-support';
 import { buildColumn } from '@upfluence/hypertable/test-support/table-manager';
 
 module('Integration | Component | hyper-table-v2', function (hooks) {
@@ -14,6 +14,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
     this.tableManager = new TableManager();
     this.rowsFetcher = new RowsFetcher();
     this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+    this.intlService = this.owner.lookup('service:intl');
   });
 
   test('it fetches the columns and rows as expected', async function (assert) {
@@ -157,46 +158,192 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('.upf-checkbox').exists({ count: 3 });
     });
 
-
     test('the selection column is present when the feature is enabled', async function (assert: Assert) {
       await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
       assert.dom('.selected-count').exists();
-    })
-
-    test('clicking the checkbox in the header of the selection column triggers the SelectAll', async function (assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
-      await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
-
-      assert.deepEqual(this.handler.selection, []);
-      assert.dom('.hypertable__column.hypertable__column--selection header .upf-checkbox').exists();
-
-      await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
-      // @ts-ignore
-      assert.ok(handlerSpy.toggleSelectAll.calledOnceWithExactly(true));
-      assert.equal(this.handler.selection, 'all');
-      assert.dom('.selected-count').hasText(this.handler.rowsMeta.total.toString());
     });
 
-    test("when in SelectAll mode, all rows' selection checkboxes are disabled", async function (assert: Assert) {
-      await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
-      await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+    module('when clicking the checkbox in the header of the selection column with partial rows loaded', () => {
+      test('it triggers the handler SelectAll', async function (assert: Assert) {
+        const toggleSelectAllStub = sinon.stub(this.handler, 'toggleSelectAll');
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
-      assert
-        .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
-        .exists({ count: 2 });
-      findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
-        (checkbox) => {
-          assert.dom(checkbox).hasAttribute('disabled');
-        }
-      );
+        assert.dom('.hypertable__column.hypertable__column--selection header .upf-checkbox').exists();
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
 
-      await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
-      findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
-        (checkbox) => {
-          assert.dom(checkbox).hasNoAttribute('disabled');
-        }
-      );
+        assert.ok(toggleSelectAllStub.calledOnceWithExactly(true));
+      });
+
+      test('it updates the selected count with correct number', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert.dom('.selected-count').hasText(this.handler.selection.length.toString());
+      });
+
+      test('it renders the partial mode for the head checkbox', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert
+          .dom('.hypertable__column.hypertable__column--selection header .upf-checkbox label')
+          .hasClass('upf-checkbox__fake-checkbox--partial');
+      });
+
+      test('HyperTableV2::Selection component renders correct value', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert
+          .dom('.selection-container .count-container span')
+          .hasText(
+            this.intlService.t('hypertable.selection.creator_selected', { count: this.handler.selection.length })
+          );
+        assert
+          .dom('.selection-container .select-all-container')
+          .hasText(this.intlService.t('hypertable.selection.select_all', { count: this.handler.rowsMeta.total }));
+      });
+    });
+
+    module('when clicking the checkbox in the header of the selection column with all rows loaded', (hooks) => {
+      hooks.beforeEach(function () {
+        this.rowsFetcher = new AllRowsFetcher();
+        this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+      });
+
+      test('it triggers the handler SelectAll', async function (assert: Assert) {
+        const toggleSelectAllStub = sinon.stub(this.handler, 'toggleSelectAll');
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+
+        assert.dom('.hypertable__column.hypertable__column--selection header .upf-checkbox').exists();
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert.ok(toggleSelectAllStub.calledOnceWithExactly(true));
+      });
+
+      test('it updates the selected count with correct number', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert.dom('.selected-count').hasText(this.handler.rowsMeta.total.toString());
+      });
+
+      test('it renders the checked mode for the head checkbox', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        assert
+          .dom('.hypertable__column.hypertable__column--selection header .upf-checkbox label')
+          .doesNotHaveClass('upf-checkbox__fake-checkbox--partial');
+        assert.dom('.hypertable__column.hypertable__column--selection header .upf-checkbox input').isChecked();
+      });
+
+      test('HyperTableV2::Selection component renders correct value', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+
+        const countText = document.querySelector('.selection-container .count-container span')?.innerHTML;
+        assert.equal(
+          this.intlService.t('hypertable.selection.all_creators_selected', { count: this.handler.rowsMeta.total }),
+          countText
+        );
+        assert.dom('.selection-container .select-all-container').doesNotExist();
+      });
+    });
+
+    module('when header checkbox is check with partial select all', () => {
+      test('all checkboxes of loaded rows are selected', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        assert
+          .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
+          .exists({ count: 2 });
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isChecked();
+          }
+        );
+
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isNotChecked();
+          }
+        );
+      });
+
+      test('all checkboxes of new rows are not selected', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        await this.handler.fetchRows();
+        await assert.expect(9);
+
+        assert
+          .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
+          .exists({ count: 4 });
+
+        const checkboxes = document.querySelectorAll(
+          '.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input'
+        );
+        [0, 1].forEach((index) => {
+          assert.dom(checkboxes[index]).isChecked();
+        });
+        [2, 3].forEach((index) => {
+          assert.dom(checkboxes[index]).isNotChecked();
+        });
+
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        checkboxes.forEach((checkbox) => {
+          assert.dom(checkbox).isNotChecked();
+        });
+      });
+    });
+
+    module('when header checkbox is check with global select all', () => {
+      test('all checkboxes of loaded rows are selected', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        await this.handler.selectAllGlobal();
+
+        assert
+          .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
+          .exists({ count: 2 });
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isChecked();
+          }
+        );
+
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isNotChecked();
+          }
+        );
+      });
+
+      test('all checkboxes of new rows are also selected', async function (assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        await this.handler.fetchRows();
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        await this.handler.selectAllGlobal();
+        assert
+          .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
+          .exists({ count: 4 });
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isChecked();
+          }
+        );
+
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
+          (checkbox) => {
+            assert.dom(checkbox).isNotChecked();
+          }
+        );
+      });
     });
 
     test('clicking a row selection checkbox toggles its selection status', async function (assert: Assert) {
@@ -223,6 +370,54 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
         .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input')
         .isNotChecked();
       assert.dom('.selected-count').hasText('0');
+    });
+
+    test('clicking on all row selection checkbox toggles the select all', async function (assert: Assert) {
+      this.rowsFetcher = new AllRowsFetcher();
+      this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+      const handlerSpy = sinon.spy(this.handler);
+
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+
+      assert.deepEqual(this.handler.selection, []);
+
+      await click('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox');
+      // @ts-ignore
+      assert.ok(handlerSpy.updateSelection.calledWithExactly(this.handler.rows[0]));
+      assert.equal(this.handler.selection.length, 1);
+      await click('.hypertable__column.hypertable__column--selection .hypertable__cell:last-child .upf-checkbox');
+      // @ts-ignore
+      assert.ok(handlerSpy.updateSelection.calledWithExactly(this.handler.rows[1]));
+      // await this.pauseTest();
+      assert.equal(this.handler.selection, 'all');
+    });
+
+    test('clicking a row selection checkbox toggles its exclusion status', async function (assert: Assert) {
+      const handlerSpy = sinon.spy(this.handler);
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+
+      await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+      await this.handler.selectAllGlobal();
+      assert.deepEqual(this.handler.exclusion, []);
+
+      await click('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox');
+
+      // @ts-ignore
+      assert.ok(handlerSpy.updateExclusion.calledWithExactly(this.handler.rows[0]));
+      assert.equal(this.handler.exclusion.length, 1);
+      assert.ok(this.handler.exclusion.includes(this.handler.rows[0]));
+      assert
+        .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input')
+        .isNotChecked();
+      assert.dom('.selected-count').hasText('11');
+
+      await click('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox');
+
+      // @ts-ignore
+      assert.ok(handlerSpy.updateExclusion.calledWithExactly(this.handler.rows[0]));
+      assert.equal(this.handler.exclusion.length, 0);
+      assert.dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').isChecked();
+      assert.dom('.selected-count').hasText('12');
     });
   });
 

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { FieldSize, Row } from '@upfluence/hypertable/core/interfaces';
-import { TableManager, RowsFetcher } from '@upfluence/hypertable/test-support';
+import { TableManager, RowsFetcher, AllRowsFetcher } from '@upfluence/hypertable/test-support';
 import BaseRenderingResolver from '@upfluence/hypertable/core/rendering-resolver';
 
 module('Unit | core/handler', function (hooks) {
@@ -215,9 +215,9 @@ module('Unit | core/handler', function (hooks) {
 
     await handler.fetchRows();
 
-    let didRefresh = handler.mutateRow(12, (row: Row) :boolean => {
-      row.bar = 'woop woop'
-      return true
+    let didRefresh = handler.mutateRow(12, (row: Row): boolean => {
+      row.bar = 'woop woop';
+      return true;
     });
 
     assert.equal(handler.rows[0].bar, 'woop woop');
@@ -225,7 +225,7 @@ module('Unit | core/handler', function (hooks) {
     assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('mutate-rows'));
     assert.true(didRefresh);
 
-    didRefresh = handler.mutateRow(13, () :boolean => false);
+    didRefresh = handler.mutateRow(13, (): boolean => false);
     assert.equal(handler.rows[1].bar, 'second bar');
     // @ts-ignore
     assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('mutate-rows'));
@@ -244,15 +244,108 @@ module('Unit | core/handler', function (hooks) {
     assert.equal(handler.currentPage, 1);
   });
 
-  test('Handler#toggleSelectAll', function (assert: Assert) {
+  module('Handler#toggleSelectAll', () => {
+    test('it selects all the loaded rows', async function (assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      assert.deepEqual(handler.selection, []);
+
+      await handler.fetchRows();
+      handler.toggleSelectAll(true);
+      assert.equal(handler.selection.length, 2);
+    });
+
+    test('it selects all the rows', async function (assert: Assert) {
+      this.rowsFetcher = new AllRowsFetcher();
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      assert.deepEqual(handler.selection, []);
+
+      await handler.fetchRows();
+      handler.toggleSelectAll(true);
+      assert.equal(handler.selection, 'all');
+    });
+
+    test('it clears the selected rows', async function (assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      assert.deepEqual(handler.selection, []);
+      await handler.fetchRows();
+
+      handler.toggleSelectAll(true);
+      handler.toggleSelectAll(false);
+
+      assert.deepEqual(handler.selection, []);
+    });
+  });
+
+  test('Handler#selectAllGlobal', async function (assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
-    assert.deepEqual(handler.selection, []);
+    handler.selection = [
+      {
+        influencerId: 42,
+        recordId: 12,
+        record_id: 12,
+        holderId: 57,
+        holderType: 'list',
+        foo: 'ekip',
+        bar: 'hello',
+        total: 123,
+        date: 1643386394
+      }
+    ];
+    handler.exclusion = [
+      {
+        influencerId: 42,
+        recordId: 12,
+        record_id: 12,
+        holderId: 57,
+        holderType: 'list',
+        foo: 'ekip',
+        bar: 'hello',
+        total: 123,
+        date: 1643386394
+      }
+    ];
+    assert.equal(handler.selection.length, 1);
+    assert.equal(handler.exclusion.length, 1);
 
-    handler.toggleSelectAll(true);
-    assert.deepEqual(handler.selection, 'all');
+    handler.selectAllGlobal();
+    assert.equal(handler.selection, 'all');
+    assert.deepEqual(handler.exclusion, []);
+  });
 
-    handler.toggleSelectAll(false);
+  test('Handler#selectAllGlobal', async function (assert) {
+    const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+    handler.selection = [
+      {
+        influencerId: 42,
+        recordId: 12,
+        record_id: 12,
+        holderId: 57,
+        holderType: 'list',
+        foo: 'ekip',
+        bar: 'hello',
+        total: 123,
+        date: 1643386394
+      }
+    ];
+    handler.exclusion = [
+      {
+        influencerId: 42,
+        recordId: 12,
+        record_id: 12,
+        holderId: 57,
+        holderType: 'list',
+        foo: 'ekip',
+        bar: 'hello',
+        total: 123,
+        date: 1643386394
+      }
+    ];
+    assert.equal(handler.selection.length, 1);
+    assert.equal(handler.exclusion.length, 1);
+
+    handler.clearSelection();
     assert.deepEqual(handler.selection, []);
+    assert.deepEqual(handler.exclusion, []);
   });
 
   test('Handler#updateSelection', async function (assert: Assert) {

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -278,32 +278,7 @@ module('Unit | core/handler', function (hooks) {
 
   test('Handler#selectAllGlobal', async function (assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
-    handler.selection = [
-      {
-        influencerId: 42,
-        recordId: 12,
-        record_id: 12,
-        holderId: 57,
-        holderType: 'list',
-        foo: 'ekip',
-        bar: 'hello',
-        total: 123,
-        date: 1643386394
-      }
-    ];
-    handler.exclusion = [
-      {
-        influencerId: 42,
-        recordId: 12,
-        record_id: 12,
-        holderId: 57,
-        holderType: 'list',
-        foo: 'ekip',
-        bar: 'hello',
-        total: 123,
-        date: 1643386394
-      }
-    ];
+    populateSelectionAndExclusionHandler(handler);
     assert.equal(handler.selection.length, 1);
     assert.equal(handler.exclusion.length, 1);
 
@@ -314,32 +289,7 @@ module('Unit | core/handler', function (hooks) {
 
   test('Handler#selectAllGlobal', async function (assert) {
     const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
-    handler.selection = [
-      {
-        influencerId: 42,
-        recordId: 12,
-        record_id: 12,
-        holderId: 57,
-        holderType: 'list',
-        foo: 'ekip',
-        bar: 'hello',
-        total: 123,
-        date: 1643386394
-      }
-    ];
-    handler.exclusion = [
-      {
-        influencerId: 42,
-        recordId: 12,
-        record_id: 12,
-        holderId: 57,
-        holderType: 'list',
-        foo: 'ekip',
-        bar: 'hello',
-        total: 123,
-        date: 1643386394
-      }
-    ];
+    populateSelectionAndExclusionHandler(handler);
     assert.equal(handler.selection.length, 1);
     assert.equal(handler.exclusion.length, 1);
 
@@ -421,4 +371,20 @@ module('Unit | core/handler', function (hooks) {
       assert.expect(1);
     });
   });
+
+  function populateSelectionAndExclusionHandler(handler: TableHandler): void {
+    const row = {
+      influencerId: 42,
+      recordId: 12,
+      record_id: 12,
+      holderId: 57,
+      holderType: 'list',
+      foo: 'ekip',
+      bar: 'hello',
+      total: 123,
+      date: 1643386394
+    };
+    handler.selection = [row];
+    handler.exclusion = [row];
+  }
 });


### PR DESCRIPTION
### What does this PR do?

Hypertable v2 support new selection
Add tests

Related to : https://github.com/upfluence/backlog/issues/2319

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
