### PR TITLE
Added: disableAutoResize argument on HypertableV1

### DIFF
--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -161,7 +161,9 @@ export default Component.extend({
   init() {
     this._super();
 
-    $(window).on('resize', this._resizeInnerTable.bind(this));
+    if (!this.disableAutoResize) {
+      $(window).on('resize', this._resizeInnerTable.bind(this));
+    }
 
     // eslint-disable-next-line ember/no-incorrect-calls-with-inline-anonymous-functions
     run.scheduleOnce('afterRender', this, () => {
@@ -187,7 +189,9 @@ export default Component.extend({
     // eslint-disable-next-line ember/no-incorrect-calls-with-inline-anonymous-functions
     once(() => {
       this.set('_innerTable', document.querySelector('.hypertable__table'));
-      this._resizeInnerTable();
+      if (!this.disableAutoResize) {
+        this._resizeInnerTable();
+      }
     });
   },
 


### PR DESCRIPTION
### What does this PR do?

Adds the option on hypertableV1 to disableAutoResize functions by passing the `disableAutoResize` to true in the parameters. Default behavior is to allow it.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
