### PR TITLE
Fix drag icon overlapping the filter trigger

### DIFF
--- a/addon/components/hyper-table/index.hbs
+++ b/addon/components/hyper-table/index.hbs
@@ -207,7 +207,7 @@
     {{#each this._columns as |column index|}}
       {{#if (gt index 0)}}
         <HyperTable::Column
-          @column={{column}} @manager={{this.manager}} {{sortable-item model=column onDragStart=(action "dragStarted")}}>
+          @column={{column}} @manager={{this.manager}} {{sortable-item model=column spacing=5 distance=10 onDragStart=(action "dragStarted")}}>
           {{#if this.loadingData}}
             {{#each this._loadingCollection}}
               <HyperTable::Cell @loading={{true}} />

--- a/app/styles/columns.less
+++ b/app/styles/columns.less
@@ -129,9 +129,6 @@
     i {
       opacity: 0;
       font-size: 16 / @rem;
-      &.fa-bars {
-        padding: var(--spacing-px-6) 0;
-      }
       &.fa-filter {
         padding: var(--spacing-px-12);
       }


### PR DESCRIPTION
### What does this PR do?

Fix drag icon overlapping the filter trigger

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
