### PR TITLE
Prevent unecessary record refresh when the record is not loaded

### DIFF
--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -115,10 +115,7 @@ export default class TableHandler {
       throw new Error('[Hypertable/Handler] The RowsFetcher in use does not support fetchById.');
     }
 
-    const matchingRow = this.rows.find((row: Row) => {
-      return row.record_id === recordId;
-    });
-    if (!matchingRow) return Promise.resolve();
+    if (!this.rows.find((row: Row) => row.record_id === recordId)) return Promise.resolve();
 
     return this.rowsFetcher.fetchById(recordId).then((updatedRow: Row) => {
       this.mutateRow(recordId, (row) => {

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -115,6 +115,11 @@ export default class TableHandler {
       throw new Error('[Hypertable/Handler] The RowsFetcher in use does not support fetchById.');
     }
 
+    const matchingRow = this.rows.find((row: Row) => {
+      return row.record_id === recordId;
+    });
+    if (!matchingRow) return Promise.resolve();
+
     return this.rowsFetcher.fetchById(recordId).then((updatedRow: Row) => {
       this.mutateRow(recordId, (row) => {
         Object.keys(updatedRow).forEach((key) => {

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -360,6 +360,19 @@ module('Unit | core/handler', function (hooks) {
   });
 
   module('Handler#updateRowById', function () {
+    test('it skips the row refresh if the record_id is not loaded yet', async function (assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      const rowsFetcherSpy = sinon.spy(this.rowsFetcher);
+      await handler.fetchRows();
+
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.bar, 'hello');
+      await handler.updateRowById(667);
+
+      // @ts-ignore
+      assert.ok(rowsFetcherSpy.fetchById.notCalled)
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.bar, 'hello');
+    });
+
     test('it calls the updateRowById method of the manager correctly', async function (assert: Assert) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
       const rowsFetcherSpy = sinon.spy(this.rowsFetcher);


### PR DESCRIPTION
### What does this PR do?

Prevent unecessary record refresh when the record is not loaded

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
