### PR TITLE
[Cooldown] Facet rendering improvement

### DIFF
--- a/addon/components/hyper-table/facetting.hbs
+++ b/addon/components/hyper-table/facetting.hbs
@@ -18,7 +18,7 @@
           class="margin-right-px-12" />
 
         {{#if facet.facetRenderer}}
-          {{facet.facetRenderer}}
+          {{component facet.facetRenderer facet=facet}}
         {{else}}
           <span class={{if facet.applied "text-style-bold"}}>
             {{facet.formattedIdentifier}}


### PR DESCRIPTION
### What does this PR do?

Facet rendering improvement. The method to build the faceting in the irm change for `_buildFacet` method declaring `facetRenderer`. Only `entity-object` filter renderer is affected.

Related to : https://linear.app/upfluence/issue/ENG-168/tooltip-replace-legacy-tooltips

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
