### PR TITLE
Skip duplicated rows

### DIFF
--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -98,7 +98,7 @@ export default class TableHandler {
     return this.rowsFetcher
       .fetch(this.currentPage, 20)
       .then(({ rows, meta }) => {
-        this.rows = [...this.rows, ...rows];
+        this.rows = [...this.rows, ...rows.filter((row) => !this.rows.map((r) => r.record_id).includes(row.record_id))];
         this.rowsMeta = meta;
         this.currentPage += 1;
       })

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -274,6 +274,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
 
       test('all checkboxes of new rows are not selected', async function (assert: Assert) {
+        stubFetchMultipleRows(this.handler);
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
         await this.handler.fetchRows();
@@ -324,6 +325,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       });
 
       test('all checkboxes of new rows are also selected', async function (assert: Assert) {
+        stubFetchMultipleRows(this.handler);
         await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
         await this.handler.fetchRows();
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
@@ -489,4 +491,65 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('#example-contextual-action-named-block').exists();
     });
   });
+
+  function stubFetchMultipleRows(handler: TableHandler): void {
+    sinon
+      .stub(handler.rowsFetcher, 'fetch')
+      .onFirstCall()
+      .resolves({
+        rows: [
+          {
+            influencerId: 42,
+            recordId: 12,
+            record_id: 12,
+            holderId: 57,
+            holderType: 'list',
+            foo: 'ekip',
+            bar: 'hello',
+            total: 123,
+            date: 1643386394
+          },
+          {
+            influencerId: 43,
+            recordId: 13,
+            record_id: 13,
+            holderId: 57,
+            holderType: 'list',
+            foo: 'second',
+            bar: 'second bar',
+            total: 123123,
+            date: 0
+          }
+        ],
+        meta: { total: 12 }
+      })
+      .onSecondCall()
+      .resolves({
+        rows: [
+          {
+            influencerId: 49,
+            recordId: 13,
+            record_id: 14,
+            holderId: 57,
+            holderType: 'list',
+            foo: 'third',
+            bar: 'third bar',
+            total: 65,
+            date: 1643396394
+          },
+          {
+            influencerId: 44,
+            recordId: 14,
+            record_id: 14,
+            holderId: 69,
+            holderType: 'list',
+            foo: 'fourth',
+            bar: 'fourth bar',
+            total: 1231,
+            date: 0
+          }
+        ],
+        meta: { total: 12 }
+      });
+  }
 });

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -44,9 +44,9 @@ module('Unit | core/handler', function (hooks) {
     test('it removes duplicated row by record_id', async function (assert: Assert) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
       stubFetchRowForDuplication(handler);
+      await handler.fetchRows();
+      await handler.fetchRows();
 
-      await handler.fetchRows();
-      await handler.fetchRows();
       assert.equal(handler.rows.length, 3);
       assert.equal(handler.rows[0].record_id, 12);
       assert.equal(handler.rows[0].foo, 'ekip');


### PR DESCRIPTION
### What does this PR do?

Skip duplicated rows

Related to : https://linear.app/upfluence/issue/ENG-1945/skip-rowsfetcher-new-rows-that-are-already-in-the-table

### What are the observable changes?

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
