### PR TITLE
[VEL-3593]  Explicitely import Tether via ESM import instead of relying on global definition

### DIFF
--- a/addon/types/table.js
+++ b/addon/types/table.js
@@ -1,9 +1,10 @@
-/* global Tether */
 import EmberObject, { computed } from '@ember/object';
 import { or } from '@ember/object/computed';
 import { scheduleOnce } from '@ember/runloop';
 import { isEmpty, typeOf } from '@ember/utils';
 import { dasherize } from '@ember/string';
+
+import Tether from 'tether';
 
 import Column from '@upfluence/hypertable/types/column';
 import { LocalStorageStore } from '@upfluence/hypertable/types/store';


### PR DESCRIPTION
### What does this PR do?

[Hypertable v1] Instead of relying on the presence of Tether in the global scope, import it explicitely from the packages. This was actually only working because the final apps had Tether in the global scope via ember-tether (which is removed in https://github.com/upfluence/ember-upf-utils/pull/397 and https://github.com/upfluence/facade-web/pull/597).

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
