### PR TITLE
Fixed: IRM empty state not displaying correctly

### DIFF
--- a/addon/components/hyper-table/index.hbs
+++ b/addon/components/hyper-table/index.hbs
@@ -161,7 +161,7 @@
   {{/if}}
 
   {{#if (and (eq this._collection.length 0) (not this.loadingData))}}
-    <div class="hypertable__state hypertable__state--empty" {{did-insert (action "centerElement")}}>
+    <div class="hypertable__state hypertable__state--empty" {{did-insert (action "scrollToEmptyState")}}>
       {{#if (has-block "inverse")}}
         {{yield to="inverse"}}
       {{else}}

--- a/addon/components/hyper-table/index.hbs
+++ b/addon/components/hyper-table/index.hbs
@@ -161,7 +161,7 @@
   {{/if}}
 
   {{#if (and (eq this._collection.length 0) (not this.loadingData))}}
-    <div class="hypertable__state hypertable__state--empty">
+    <div class="hypertable__state hypertable__state--empty" {{did-insert (action "centerElement")}}>
       {{#if (has-block "inverse")}}
         {{yield to="inverse"}}
       {{else}}

--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -212,7 +212,7 @@ export default Component.extend({
       this._doSearch();
     },
 
-    centerElement(element) {
+    scrollToEmptyState(element) {
       element?.scrollIntoView({ inline: 'center' });
     },
 

--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -212,6 +212,10 @@ export default Component.extend({
       this._doSearch();
     },
 
+    centerElement(element) {
+      element?.scrollIntoView({inline: 'center'})
+    },
+
     reorderColumns(itemModels) {
       let _cs = [this._columns[0]].concat(itemModels);
       let hasSameOrder = compare(_cs.mapBy('key'), this.manager.columns.mapBy('key')) === 0;

--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -213,7 +213,7 @@ export default Component.extend({
     },
 
     centerElement(element) {
-      element?.scrollIntoView({inline: 'center'})
+      element?.scrollIntoView({ inline: 'center' })
     },
 
     reorderColumns(itemModels) {

--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -213,7 +213,7 @@ export default Component.extend({
     },
 
     centerElement(element) {
-      element?.scrollIntoView({ inline: 'center' })
+      element?.scrollIntoView({ inline: 'center' });
     },
 
     reorderColumns(itemModels) {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

On search / filter with no results, auto-scrolls back to the beginning of the table to display empty state correctly.

Related to : #[DRA-1532](https://linear.app/upfluence/issue/DRA-1532/irm-empty-state-not-displaying)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
