### PR TITLE
hyper-table-v2/filtering-renderers/date: allow moving option key to be extended

### DIFF
--- a/addon-test-support/rows-fetcher.ts
+++ b/addon-test-support/rows-fetcher.ts
@@ -26,6 +26,17 @@ export default class RowsFetcher {
           bar: 'second bar',
           total: 123123,
           date: 0
+        },
+        {
+          influencerId: 44,
+          recordId: 14,
+          record_id: 14,
+          holderId: 58,
+          holderType: 'list',
+          foo: null,
+          bar: 'second bar',
+          total: null,
+          date: 0
         }
       ],
       meta: { total: 12 }

--- a/addon/components/hyper-table-v2/cell-renderers/date.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/date.hbs
@@ -1,5 +1,7 @@
 {{#if this.value}}
   {{this.formattedDate}}
 {{else}}
-  —
+  <span class="font-color-gray-500">
+    {{or @column.definition.empty_state_message "—"}}
+  </span>
 {{/if}}

--- a/addon/components/hyper-table-v2/cell-renderers/numeric.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/numeric.hbs
@@ -6,6 +6,8 @@
   </div>
 {{else}}
   <div class="fx-row fx-1 fx-malign-start">
-    —
+    <span class="font-color-gray-500">
+      {{or @column.definition.empty_state_message "—"}}
+    </span>
   </div>
 {{/if}}

--- a/addon/components/hyper-table-v2/cell-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/text.hbs
@@ -3,5 +3,7 @@
     {{this.value}}
   </span>
 {{else}}
-  —
+  <span class="font-color-gray-500">
+    —
+  </span>
 {{/if}}

--- a/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/search.ts
@@ -10,10 +10,12 @@ import { onlyNumeric } from '@upfluence/hypertable/utils';
 interface HyperTableV2FilteringRenderersSearchArgs {
   handler: TableHandler;
   column: Column;
+  filterKey?: string;
   type?: string;
 }
 
 const SEARCH_DEBOUNCE_TIME: number = 300;
+const DEFAULT_FILTER_KEY: string = 'value';
 
 export default class HyperTableV2FilteringRenderersSearch extends Component<HyperTableV2FilteringRenderersSearchArgs> {
   @tracked searchQuery: string = '';
@@ -28,6 +30,10 @@ export default class HyperTableV2FilteringRenderersSearch extends Component<Hype
         this.searchQuery = '';
       }
     });
+  }
+
+  get filterKey(): string {
+    return this.args.filterKey ?? DEFAULT_FILTER_KEY;
   }
 
   setupOnlyNumericListener(element: HTMLElement): void {
@@ -55,7 +61,7 @@ export default class HyperTableV2FilteringRenderersSearch extends Component<Hype
   private _applyFilters(): void {
     this.args.handler.applyFilters(this.args.column, [
       {
-        key: 'value',
+        key: this.filterKey,
         value: this.searchQuery
       }
     ]);

--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -20,7 +20,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   @tracked _currentMovingDateOption: any;
   @tracked filterOption: FilterOption;
 
-  protected movingOptionKey = DEFAULT_MOVING_OPTION_KEY;
+  protected movingOptionKey: FilterOption = DEFAULT_MOVING_OPTION_KEY;
 
   private _calendarContainer: any = null;
 

--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -11,17 +11,21 @@ interface HyperTableV2FilteringRenderersDateArgs {
   column: Column;
 }
 
-type FilterOption = 'moving' | 'fixed';
+export type FilterOption = 'moving' | 'fixed';
+
+const DEFAULT_MOVING_OPTION_KEY: FilterOption = 'moving';
 
 export default class HyperTableV2FilteringRenderersDate extends Component<HyperTableV2FilteringRenderersDateArgs> {
   @tracked _currentDateValue: Date[] = [];
   @tracked _currentMovingDateOption: any;
   @tracked filterOption: FilterOption;
 
+  protected movingOptionKey = DEFAULT_MOVING_OPTION_KEY;
+
   private _calendarContainer: any = null;
 
   filteringOptions: { label: string; value: FilterOption }[] = [
-    { label: 'Moving', value: 'moving' },
+    { label: 'Moving', value: this.movingOptionKey },
     { label: 'Fixed', value: 'fixed' }
   ];
 
@@ -42,9 +46,9 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   constructor(owner: unknown, args: HyperTableV2FilteringRenderersDateArgs) {
     super(owner, args);
 
-    let filter = this.args.column.filters.find((f) => f.key === 'moving');
+    let filter = this.args.column.filters.find((f) => f.key === this.movingOptionKey);
     this._currentMovingDateOption = filter ? filter.value : null;
-    this.filterOption = this._currentMovingDateOption ? 'moving' : 'fixed';
+    this.filterOption = this._currentMovingDateOption ? this.movingOptionKey : 'fixed';
     args.handler.on('reset-columns', (columns) => {
       if (columns.includes(args.column)) {
         this._resetStates();
@@ -92,7 +96,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
     this.args.handler.applyFilters(this.args.column, [
       { key: 'lower_bound', value: '' },
       { key: 'upper_bound', value: '' },
-      { key: 'moving', value: value }
+      { key: this.movingOptionKey, value: value }
     ]);
   }
 
@@ -102,7 +106,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
 
     if (fromDate && toDate) {
       this.args.handler.applyFilters(this.args.column, [
-        { key: 'moving', value: '' },
+        { key: this.movingOptionKey, value: '' },
         { key: 'lower_bound', value: (+fromDate / 1000).toString() },
         { key: 'upper_bound', value: (+toDate / 1000).toString() }
       ]);

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -19,6 +19,7 @@ export type ColumnDefinition = {
   filterable_by: string[] | null;
   facetable: boolean;
   facetable_by: string[] | null;
+  empty_state_message?: string;
   position?: {
     sticky: boolean;
   };

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -42,9 +42,9 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
   test('it sets up the rows correctly', async function (assert: Assert) {
     await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
 
-    assert.dom('.hypertable__cell').exists({ count: 8 });
-    assert.dom('.hypertable__sticky-columns .hypertable__column .hypertable__cell').exists({ count: 2 });
-    assert.dom('.hypertable__column:nth-child(2) .hypertable__cell').exists({ count: 2 });
+    assert.dom('.hypertable__cell').exists({ count: 12 });
+    assert.dom('.hypertable__sticky-columns .hypertable__column .hypertable__cell').exists({ count: 3 });
+    assert.dom('.hypertable__column:nth-child(2) .hypertable__cell').exists({ count: 3 });
   });
 
   test('it resets the filters', async function (assert: Assert) {
@@ -155,7 +155,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
 
       assert.dom('.hypertable__column.hypertable__column--selection').exists();
-      assert.dom('.upf-checkbox').exists({ count: 3 });
+      assert.dom('.upf-checkbox').exists({ count: 4 });
     });
 
     test('the selection column is present when the feature is enabled', async function (assert: Assert) {
@@ -258,7 +258,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
         await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
         assert
           .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
-          .exists({ count: 2 });
+          .exists({ count: 3 });
         findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
           (checkbox) => {
             assert.dom(checkbox).isChecked();
@@ -309,7 +309,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
 
         assert
           .dom('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox')
-          .exists({ count: 2 });
+          .exists({ count: 3 });
         findAll('.hypertable__column.hypertable__column--selection .hypertable__cell .upf-checkbox input').forEach(
           (checkbox) => {
             assert.dom(checkbox).isChecked();

--- a/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
@@ -42,4 +42,16 @@ module('Integration | Component | hyper-table-v2/cell-renderers/date', function 
     assert.equal(this.row[this.column.definition.key], '0');
     assert.dom().hasText('—');
   });
+
+  test('it renders @column.definition.empty_state_message when present and the value is null', async function (assert) {
+    this.column = this.handler.columns[3];
+    this.column.definition.empty_state_message = 'No date';
+    this.row = this.handler.rows[1];
+
+    await render(
+      hbs`<HyperTableV2::CellRenderers::Date @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
+    );
+
+    assert.dom().hasText('No date');
+  });
 });

--- a/tests/integration/components/hyper-table-v2/cell-renderers/numeric-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/numeric-test.ts
@@ -42,4 +42,27 @@ module('Integration | Component | hyper-table-v2/cell-renderers/numeric', functi
     assert.equal(this.row[this.column.definition.key], '123123');
     assert.dom().hasText('123k');
   });
+
+  test('it renders a default - when the value is null', async function (assert) {
+    this.column = this.handler.columns[2];
+    this.row = this.handler.rows[2];
+
+    await render(
+      hbs`<HyperTableV2::CellRenderers::Numeric @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
+    );
+
+    assert.dom().hasText('—');
+  });
+
+  test('it renders @column.definition.empty_state_message when present and the value is null', async function (assert) {
+    this.column = this.handler.columns[2];
+    this.column.definition.empty_state_message = 'Custom empty';
+    this.row = this.handler.rows[2];
+
+    await render(
+      hbs`<HyperTableV2::CellRenderers::Numeric @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
+    );
+
+    assert.dom().hasText('Custom empty');
+  });
 });

--- a/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/text-test.ts
@@ -29,4 +29,15 @@ module('Integration | Component | hyper-table-v2/cell-renderers/text', function 
     assert.equal(this.row[this.column.definition.key], 'ekip');
     assert.dom('span').hasText('ekip');
   });
+
+  test('it renders a default - when the value is null', async function (assert) {
+    this.column = this.handler.columns[0];
+    this.row = this.handler.rows[2];
+
+    await render(
+      hbs`<HyperTableV2::CellRenderers::Text @handler={{this.handler}} @row={{this.row}} @column={{this.column}} />`
+    );
+
+    assert.dom().hasText('—');
+  });
 });

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/search-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/search-test.ts
@@ -38,7 +38,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/sear
     assert.dom('.oss-input-container').exists();
   });
 
-  test('When text is inputed, the applyFilters is called', async function (assert: Assert) {
+  test('When text is inputted, the applyFilters is called', async function (assert: Assert) {
     const handlerSpy = sinon.spy(this.handler);
     await render(
       hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} />`
@@ -58,6 +58,32 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/common/sear
       handlerSpy.applyFilters.calledWith(this.column, [
         {
           key: 'value',
+          value: 'test'
+        }
+      ])
+    );
+  });
+
+  test('the provided filter key is used when apply filters', async function (assert: Assert) {
+    const handlerSpy = sinon.spy(this.handler);
+    await render(
+      hbs`<HyperTableV2::FilteringRenderers::Common::Search @handler={{this.handler}} @column={{this.column}} @filterKey="foobar" />`
+    );
+
+    await fillIn('.oss-input-container input', 'test');
+    await triggerKeyEvent(
+      '.oss-input-container input',
+      'keyup',
+      'Enter',
+      //@ts-ignore
+      { code: 'Enter' }
+    );
+
+    assert.ok(
+      //@ts-ignore
+      handlerSpy.applyFilters.calledWith(this.column, [
+        {
+          key: 'foobar',
           value: 'test'
         }
       ])

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -38,7 +38,7 @@ module('Unit | core/handler', function (hooks) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
       assert.equal(handler.rows.length, 0);
       await handler.fetchRows();
-      assert.equal(handler.rows.length, 2);
+      assert.equal(handler.rows.length, 3);
     });
 
     test('it removes duplicated row by record_id', async function (assert: Assert) {
@@ -224,7 +224,7 @@ module('Unit | core/handler', function (hooks) {
       handler.applyOrder(handler.columns[1], 'asc');
       handler.toggleSelectAll(true);
 
-      assert.equal(handler.selection.length, 2);
+      assert.equal(handler.selection.length, 3);
 
       handler.resetColumns(handler.columns);
 
@@ -243,7 +243,7 @@ module('Unit | core/handler', function (hooks) {
     assert.ok(rowsFetcherSpy.fetch.calledTwice);
     // @ts-ignore
     assert.ok(rowsFetcherSpy.fetch.calledWithExactly(1, 20));
-    assert.equal(handler.rows.length, 2);
+    assert.equal(handler.rows.length, 3);
   });
 
   test('Handler#removeRow', async function (assert: Assert) {
@@ -251,10 +251,10 @@ module('Unit | core/handler', function (hooks) {
     const handlerTriggerEventSpy = sinon.spy(handler, 'triggerEvent');
 
     await handler.fetchRows();
-    assert.equal(handler.rows.length, 2);
+    assert.equal(handler.rows.length, 3);
 
     handler.removeRow(12);
-    assert.equal(handler.rows.length, 1);
+    assert.equal(handler.rows.length, 2);
     assert.equal(handler.rows[0].recordId, 13);
     // @ts-ignore
     assert.ok(handlerTriggerEventSpy.calledOnceWithExactly('remove-row'));
@@ -302,7 +302,7 @@ module('Unit | core/handler', function (hooks) {
 
       await handler.fetchRows();
       handler.toggleSelectAll(true);
-      assert.equal(handler.selection.length, 2);
+      assert.equal(handler.selection.length, 3);
     });
 
     test('it selects all the rows', async function (assert: Assert) {


### PR DESCRIPTION
### What does this PR do?

hyper-table-v2/filtering-renderers/date: allow moving option key to be extended in case the backend the API expects a different value.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
