### PR TITLE
Fixed: prevent sending upper or lowerBound filter when no value is defined

### DIFF
--- a/addon/components/hyper-table/filters-renderers/money.js
+++ b/addon/components/hyper-table/filters-renderers/money.js
@@ -1,11 +1,16 @@
 import NumericFilterRenderer from '@upfluence/hypertable/components/hyper-table/filters-renderers/numeric';
+import { isBlank } from '@ember/utils';
 
 export default NumericFilterRenderer.extend({
   _addRangeFilter() {
-    this.column.set('filters', [
-      { key: 'lower_bound', value: (this.lowerBoundFilter * 100).toString() },
-      { key: 'upper_bound', value: (this.upperBoundFilter * 100).toString() }
-    ]);
+    const filters = [];
+    if (!isBlank(this.lowerBoundFilter)) {
+      filters.push({ key: 'lower_bound', value: (this.lowerBoundFilter * 100).toString() });
+    }
+    if (!isBlank(this.upperBoundFilter)) {
+      filters.push({ key: 'upper_bound', value: (this.upperBoundFilter * 100).toString() });
+    }
+    this.column.set('filters', filters);
     this.manager.hooks.onColumnsChange('columns:change');
   },
 

--- a/addon/components/hyper-table/filters-renderers/money.js
+++ b/addon/components/hyper-table/filters-renderers/money.js
@@ -3,7 +3,8 @@ import { isBlank } from '@ember/utils';
 
 export default NumericFilterRenderer.extend({
   _addRangeFilter() {
-    const filters = [];
+    let filters = [];
+
     if (!isBlank(this.lowerBoundFilter)) {
       filters.push({ key: 'lower_bound', value: (this.lowerBoundFilter * 100).toString() });
     }
@@ -20,11 +21,11 @@ export default NumericFilterRenderer.extend({
       let lowerBound = this.column.filters.findBy('key', 'lower_bound');
       let upperBound = this.column.filters.findBy('key', 'upper_bound');
 
-      if (lowerBound && upperBound) {
-        this.setProperties({
-          lowerBoundFilter: lowerBound.value / 100,
-          upperBoundFilter: upperBound.value / 100
-        });
+      if (!isBlank(lowerBound)) {
+        this.setProperties({ lowerBoundFilter: lowerBound.value / 100 });
+      }
+      if (!isBlank(upperBound)) {
+        this.setProperties({ upperBoundFilter: upperBound.value / 100 });
       }
     }
   },


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where we send "NaN" in a string to the backend when entering a partial From / To filter in hypertable V1:
![Screenshot 2024-12-11 at 15 54 00](https://github.com/user-attachments/assets/acb3dba7-a289-4fd4-81da-2429a8a35722)

⚠️ Also FYI, it looks like the NumericFilterRenderer defined in `money.js` file (the file updated) is used by the numeric filter renderer instead of the code stored in `numeric.js`.
As this has been the case for the past 5 years, and that we are moving all instances of hypertables to use V2, I feel it's not worth spending time changing the code here.
It's a good thing to point it out and to keep it in our minds though 😇 

Fixes this sentry issue on the backend, there's probably one on the frontend sentry board as well, but I cannot point it out:
https://upfluence.sentry.io/issues/6088772288/?referrer=Linear

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled