### PR TITLE
Add support for facets sorting (default by count)

### DIFF
--- a/addon-test-support/table-manager.ts
+++ b/addon-test-support/table-manager.ts
@@ -68,6 +68,13 @@ export default class TableManager implements ITableManager {
           payload: {
             name: 'The Foo Fighters'
           },
+          count: 29
+        },
+        {
+          identifier: 'band:2',
+          payload: {
+            name: 'Arctic Monkeys'
+          },
           count: 4
         }
       ],

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
@@ -5,7 +5,7 @@
       <OSS::InputContainer
         @value={{this.searchQuery}}
         @onChange={{this.onInputChanged}}
-        @placeholder={{t "hypertable.column.filtering.search_term.placeholder"}}
+        @placeholder={{this.searchPlaceholder}}
       >
         <:suffix>
           {{#if (gt this.searchQuery.length 0)}}

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -2,7 +2,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+
+import { IntlService } from 'ember-intl';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { Column, Facet, FacetsResponse, Filter } from '@upfluence/hypertable/core/interfaces';
@@ -12,6 +15,7 @@ interface FacetsLoaderArgs {
   column: Column;
   facettingKey: string;
   searchEnabled: boolean;
+  searchPlaceholder?: string;
   sortCompareFn?(a: Facet, b: Facet): number;
 }
 
@@ -19,6 +23,8 @@ const SEARCH_DEBOUNCE_TIME: number = 300;
 const FACET_APPLY_DEBOUNCE_TIME: number = 300;
 
 export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs> {
+  @service declare intl: IntlService;
+
   @tracked loading = false;
   @tracked facets: Facet[] = [];
   @tracked appliedFacets: string[] = [];
@@ -42,6 +48,10 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
 
   get searchEnabled(): boolean {
     return this.args.searchEnabled ?? false;
+  }
+
+  get searchPlaceholder(): string {
+    return this.args.searchPlaceholder ?? this.intl.t('hypertable.column.filtering.search_term.placeholder');
   }
 
   get skeletonStyle(): string {

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
@@ -118,6 +118,26 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
       assert.dom('.oss-input-container').exists();
     });
 
+    test('the default search placeholder is displayed when no searchPlaceholder arg is provided', async function (assert: Assert) {
+      await render(
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{true}}/>`
+      );
+
+      assert.dom('.oss-input-container').exists();
+      assert
+        .dom('.oss-input-container input')
+        .hasAttribute('placeholder', this.intl.t('hypertable.column.filtering.search_term.placeholder'));
+    });
+
+    test('the search input has the provided searchPlaceholder arg properly used', async function (assert: Assert) {
+      await render(
+        hbs`<HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{true}} @searchPlaceholder="foobar..." />`
+      );
+
+      assert.dom('.oss-input-container').exists();
+      assert.dom('.oss-input-container input').hasAttribute('placeholder', 'foobar...');
+    });
+
     test('facets are fetched with the typed keyword when searching', async function (assert: Assert) {
       const handlerSpy = sinon.spy(this.handler);
 

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/common/facets-loader-test.ts
@@ -23,7 +23,7 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
   });
 
   module('facet display', function () {
-    test('the facets are displayed correctly using the dedicated named block', async function (assert: Assert) {
+    test('the facets are displayed correctly using the dedicated named block & are ordered by count value', async function (assert: Assert) {
       await render(
         hbs`
           <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}}>
@@ -33,8 +33,32 @@ module('Integration | Component | hyper-table-v2/facets-loader', function (hooks
           </HyperTableV2::FilteringRenderers::Common::FacetsLoader>`
       );
 
-      assert.dom('.hypertable__facetting .item').exists({ count: 1 });
-      assert.dom('.hypertable__facetting .item').hasText('The Foo Fighters');
+      assert.dom('.hypertable__facetting .item').exists({ count: 2 });
+      assert.dom('.hypertable__facetting > div:nth-child(1) .item').hasText('The Foo Fighters');
+      assert.dom('.hypertable__facetting > div:nth-child(2) .item').hasText('Arctic Monkeys');
+    });
+
+    test('the facets are ordered using the @sortCompareFn arg function when provided', async function (assert: Assert) {
+      this.sortCompareFn = sinon.stub().callsFake((a, b) => {
+        if (a.payload.name < b.payload.name) return -1;
+        if (a.payload.name > b.payload.name) return 1;
+        return 0;
+      });
+
+      await render(
+        hbs`
+          <HyperTableV2::FilteringRenderers::Common::FacetsLoader @handler={{this.handler}} @column={{this.column}} @searchEnabled={{false}} @sortCompareFn={{this.sortCompareFn}}>
+            <:facet-item as |facetting|>
+              {{facetting.facet.payload.name}}
+            </:facet-item>
+          </HyperTableV2::FilteringRenderers::Common::FacetsLoader>`
+      );
+
+      assert.dom('.hypertable__facetting .item').exists({ count: 2 });
+      assert.dom('.hypertable__facetting > div:nth-child(1) .item').hasText('Arctic Monkeys');
+      assert.dom('.hypertable__facetting > div:nth-child(2) .item').hasText('The Foo Fighters');
+
+      assert.ok(this.sortCompareFn.calledOnce);
     });
   });
 

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -402,6 +402,13 @@ module('Unit | core/handler', function (hooks) {
             payload: {
               name: 'The Foo Fighters'
             },
+            count: 29
+          },
+          {
+            identifier: 'band:2',
+            payload: {
+              name: 'Arctic Monkeys'
+            },
             count: 4
           }
         ],


### PR DESCRIPTION
### What does this PR do?

Add support for facets sorting in the `FacetsLoader` component. By default, we will sort the facets by `count` while allowing support for a `sortCompareFn` arg that can be provided by the parent context to sort differently.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
