### PR TITLE
Fix deprecation: Remove this. &  usage from hypertable

### DIFF
--- a/addon/components/hyper-table/index.js
+++ b/addon/components/hyper-table/index.js
@@ -4,7 +4,6 @@ import { computed, observer } from '@ember/object';
 import { alias, and, filterBy } from '@ember/object/computed';
 import { debounce, once, scheduleOnce } from '@ember/runloop';
 import { compare, isEmpty, typeOf } from '@ember/utils';
-import $ from 'jquery';
 
 export default Component.extend({
   classNames: ['hypertable-container'],

--- a/addon/mixins/editable.js
+++ b/addon/mixins/editable.js
@@ -74,7 +74,7 @@ export default Mixin.create({
       // automatically focuses the input
       // eslint-disable-next-line ember/no-incorrect-calls-with-inline-anonymous-functions
       scheduleOnce('afterRender', this, () => {
-        this.$('.editing-input__field').focus();
+        this.element.querySelector('.editing-input__field').focus();
       });
     },
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to : #[VEL-4506](https://linear.app/upfluence/issue/VEL-4506/httpsdeprecationsemberjscomv3xtoc-jquery-event)

### What are the observable changes?
🤞none🤞

Use vanilla js eventListener for `resize` & `scroll` on hypertable v1
Use vanilla js for `autofocus` editable inputs on hypertable v1 (Tested with lastname on IRM)
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
