### PR TITLE
Scope the css var for # of columns to the table

### DIFF
--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -80,6 +80,7 @@
 
       <div
         class="hypertable"
+        style={{this.columnsCountStyle}}
         {{sortable-group direction="x" onChange=this.reorderColumns groupName=this.hypertableInstanceID}}
       >
         {{#each @handler.columns as |column index|}}

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -154,7 +154,7 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     window.location.reload();
   }
 
-  get columnsCountStyle(): string {
+  get columnsCountStyle(): ReturnType<typeof htmlSafe> {
     return htmlSafe(`--hypertable-responsive-columns-number: ${this.args.handler.columns.length - 1}`);
   }
 

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action, set } from '@ember/object';
 import { debounce, scheduleOnce } from '@ember/runloop';
 import { isEmpty } from '@ember/utils';
+import { htmlSafe } from '@ember/template';
 
 import TableHandler from '@upfluence/hypertable/core/handler';
 import { Column, Row } from '@upfluence/hypertable/core/interfaces';
@@ -151,6 +152,10 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   @action
   reloadPage(): void {
     window.location.reload();
+  }
+
+  get columnsCountStyle(): string {
+    return htmlSafe(`--hypertable-responsive-columns-number: ${this.args.handler.columns.length - 1}`);
   }
 
   private _resetFilters(): void {


### PR DESCRIPTION
### What does this PR do?

Scope the css var for # of columns to the table. This fixes an issue where if you jump between multiple tables or have multiple ones in the same page, the last one rendered would win.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
