### PR TITLE
Updated: set 23:59:59 to all date filtering toDate

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -105,6 +105,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
     let [fromDate, toDate] = value;
 
     if (fromDate && toDate) {
+      this.sendEndOfTheDayOnDate(toDate);
       this.args.handler.applyFilters(this.args.column, [
         { key: this.movingOptionKey, value: '' },
         { key: 'lower_bound', value: (+fromDate / 1000).toString() },
@@ -116,6 +117,10 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   @action
   removeColumn(): void {
     this.args.handler.removeColumn(this.args.column.definition);
+  }
+
+  private sendEndOfTheDayOnDate(date: Date): void {
+    date.setHours(23, 59, 59);
   }
 
   private _resetStates(): void {

--- a/addon/components/hyper-table/filters-renderers/date.js
+++ b/addon/components/hyper-table/filters-renderers/date.js
@@ -86,6 +86,7 @@ export default class DateFiltersRenderer extends FiltersRenderer {
     let [fromDate, toDate] = value;
 
     if (fromDate && toDate) {
+      this._sendEndOfTheDayOnDate(toDate);
       this.args.column.set('filters', [
         { key: 'lower_bound', value: (+fromDate / 1000).toString() },
         { key: 'upper_bound', value: (+toDate / 1000).toString() }
@@ -101,5 +102,9 @@ export default class DateFiltersRenderer extends FiltersRenderer {
 
     this._currentDateValue = [];
     this._currentMovingDateOption = [];
+  }
+
+  _sendEndOfTheDayOnDate(date: Date): void {
+    date.setHours(23, 59, 59);
   }
 }

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
@@ -19,6 +19,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
     this.tableManager = new TableManager();
     this.rowsFetcher = new RowsFetcher();
     this.handler = new TableHandler(this, this.tableManager, this.rowsFetcher);
+    this.handlerSpy = sinon.spy(this.handler);
 
     sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
       return Promise.resolve({
@@ -49,7 +50,6 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
     });
 
     test('it calls the Handler#applyOrder method correctly via the radio buttons', async function (this: TestContext, assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
       await render(
         hbs`<HyperTableV2::FilteringRenderers::Numeric @handler={{this.handler}} @column={{this.column}} />`
       );
@@ -59,8 +59,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
         '[data-control-name="hypertable__column_filtering_for_date_ordering"] .oss-toggle-buttons-btn:nth-child(1)'
       );
 
-      //@ts-ignore
-      assert.ok(handlerSpy.applyOrder.calledWith(this.column, 'asc'));
+      assert.ok(this.handlerSpy.applyOrder.calledWith(this.column, 'asc'));
       assert.deepEqual(this.column.order, {
         direction: 'asc',
         key: 'date'
@@ -70,8 +69,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
         'div[data-control-name="hypertable__column_filtering_for_date_ordering"] .oss-toggle-buttons-btn:nth-child(2)'
       );
 
-      //@ts-ignore
-      assert.ok(handlerSpy.applyOrder.calledWith(this.column, 'desc'));
+      assert.ok(this.handlerSpy.applyOrder.calledWith(this.column, 'desc'));
       assert.deepEqual(this.column.order, {
         direction: 'desc',
         key: 'date'
@@ -113,7 +111,6 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
     });
 
     test('when the filter is set to Moving, when clicking on a filter option, applyFilter is triggered', async function (this: TestContext, assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
 
       await click(
@@ -121,8 +118,7 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
       );
       await click('.filters__option');
       assert.ok(
-        //@ts-ignore
-        handlerSpy.applyFilters.calledWith(this.column, [
+        this.handlerSpy.applyFilters.calledWith(this.column, [
           { key: 'lower_bound', value: '' },
           { key: 'upper_bound', value: '' },
           { key: 'moving', value: 'today' }
@@ -139,6 +135,24 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
       assert.dom('div[data-control-name="hypertable__column_filtering_for_date_date_range_inputs"]').exists();
     });
 
+    test('when the date is selected in Fixed mode, the end date should be set at the end of the day 23:59:59', async function (this: TestContext, assert: Assert) {
+      await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
+
+      await click(
+        'div[data-control-name="hypertable__column_filtering_for_date_filter_by_radiogroup"] .oss-toggle-buttons-btn:nth-child(2)'
+      );
+      await click('.upf-input');
+      (document.querySelector('.today') as HTMLElement)?.click();
+      (document.querySelector('.today') as HTMLElement)?.click();
+      const timestampSetInFilters = this.handlerSpy.applyFilters.args[0][1].find(
+        (filter: any) => filter.key === 'upper_bound'
+      )?.value;
+      const dateSetInFilters = new Date(timestampSetInFilters * 1000);
+      assert.true(dateSetInFilters.getHours() === 23);
+      assert.true(dateSetInFilters.getMinutes() === 59);
+      assert.true(dateSetInFilters.getSeconds() === 59);
+    });
+
     test('clicking in the flatpickr input should open flatpickr', async function (assert: Assert) {
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
 
@@ -153,15 +167,13 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
 
   module('clear column', async function () {
     test('it calls the Handler#resetColumns with the column when the dedicated button is clicked', async function (this: TestContext, assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
       this.handler.applyFilters(this.column, [{ key: 'moving', value: 'today' }]);
       this.handler.applyOrder(this.column, 'asc');
 
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
       await click('[data-control-name="hypertable__column_filtering_for_date_clear_filters"]');
 
-      //@ts-ignore
-      assert.ok(handlerSpy.resetColumns.calledWith([this.column]));
+      assert.ok(this.handlerSpy.resetColumns.calledWith([this.column]));
       assert.equal(this.column.order, undefined);
       assert.deepEqual(this.column.filters, []);
     });
@@ -169,13 +181,10 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
 
   module('remove column', function () {
     test('it calls the Handler#removeColumn with the column when the dedicated button is clicked', async function (this: TestContext, assert: Assert) {
-      const handlerSpy = sinon.spy(this.handler);
-
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
       await click('[data-control-name="hypertable__column_filtering_for_date_remove_column"]');
 
-      //@ts-ignore
-      assert.ok(handlerSpy.removeColumn.calledWith(this.column.definition));
+      assert.ok(this.handlerSpy.removeColumn.calledWith(this.column.definition));
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where selecting the current day in the "moving" date filter renderer would lead to no results.
This was due to the fact that on the filters [fromDate, toDate], the toDate was not set to the end of the day.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled