### PR TITLE
Add timezone to moving filters on date filter renderers

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/date.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/date.ts
@@ -23,6 +23,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
   protected movingOptionKey: FilterOption = DEFAULT_MOVING_OPTION_KEY;
 
   private _calendarContainer: any = null;
+  timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   filteringOptions: { label: string; value: FilterOption }[] = [
     { label: 'Moving', value: this.movingOptionKey },
@@ -96,7 +97,7 @@ export default class HyperTableV2FilteringRenderersDate extends Component<HyperT
     this.args.handler.applyFilters(this.args.column, [
       { key: 'lower_bound', value: '' },
       { key: 'upper_bound', value: '' },
-      { key: this.movingOptionKey, value: value }
+      { key: this.movingOptionKey, value: value, extra: { timezone: this.timezone } }
     ]);
   }
 

--- a/addon/components/hyper-table/filters-renderers/date.js
+++ b/addon/components/hyper-table/filters-renderers/date.js
@@ -9,6 +9,8 @@ export default class DateFiltersRenderer extends FiltersRenderer {
   @tracked _currentMovingDateOption;
   @tracked _currentDateValue;
 
+  timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
   constructor(owner, args) {
     super(owner, args);
 
@@ -76,7 +78,7 @@ export default class DateFiltersRenderer extends FiltersRenderer {
 
   @action
   selectMovingDate(value) {
-    this.args.column.set('filters', [{ key: 'value', value: value }]);
+    this.args.column.set('filters', [{ key: 'value', value: value, extra: { timezone: this.timezone } }]);
     this._currentMovingDateOption = value;
     this.args.manager.hooks.onColumnsChange('columns:change');
   }

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -28,6 +28,7 @@ export type ColumnDefinition = {
 export type Filter = {
   key: string;
   value: string;
+  extra?: any;
 };
 
 export type OrderDirection = 'asc' | 'desc';

--- a/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/filtering-renderers/date-test.ts
@@ -110,7 +110,13 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
       assert.dom(filterOptions[5]).hasText('This Year');
     });
 
-    test('when the filter is set to Moving, when clicking on a filter option, applyFilter is triggered', async function (this: TestContext, assert: Assert) {
+    test('when the filter is set to Moving, when clicking on a filter option, applyFilter is triggered with the proper timezone in the filter extras', async function (this: TestContext, assert: Assert) {
+      let intlTimezoneStub = sinon.stub(Intl, 'DateTimeFormat').returns({
+        // @ts-ignore
+        resolvedOptions: () => {
+          return { timeZone: 'Africa/Atlantis' };
+        }
+      });
       await render(hbs`<HyperTableV2::FilteringRenderers::Date @handler={{this.handler}} @column={{this.column}} />`);
 
       await click(
@@ -121,9 +127,10 @@ module('Integration | Component | hyper-table-v2/filtering-renderers/date', func
         this.handlerSpy.applyFilters.calledWith(this.column, [
           { key: 'lower_bound', value: '' },
           { key: 'upper_bound', value: '' },
-          { key: 'moving', value: 'today' }
+          { key: 'moving', value: 'today', extra: { timezone: 'Africa/Atlantis' } }
         ])
       );
+      intlTimezoneStub.restore();
     });
 
     test('when the filter is set to Fixed, then it should show an input with the datepicker', async function (assert: Assert) {


### PR DESCRIPTION
### What does this PR do?

Add timezone to moving filters on date filter renderers

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled