### PR TITLE
Added white top & bottom shadows on hypertable v2 facets loader

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
@@ -21,41 +21,42 @@
       <div class="upf-skeleton-effect margin-top-px-6" style={{this.skeletonStyle}}></div>
     {{/each}}
   {{else}}
-    {{#each this.facets as |facet|}}
-      <div
-        class="fx-row fx-malign-space-between fx-xalign-center padding-xxx-sm"
-        role="button"
-        {{on "click" (fn this.toggleFacet facet)}}
-      >
-        <div class="fx-row item">
-          {{#if this.ongoingFacetApply}}
-            <span class="margin-right-px-12">
-              <OSS::Icon @icon="fa-spinner-third fa-spin" />
-            </span>
-          {{else}}
-            <OSS::Checkbox
-              @checked={{array-includes this.appliedFacets facet.identifier}}
-              @size="sm"
-              @onChange={{fn this.toggleFacet facet}}
-              class="margin-right-px-12"
-            />
-          {{/if}}
-          {{yield (hash appliedFacets=this.appliedFacets facet=facet) to="facet-item"}}
+    <OSS::ScrollablePanel @plain={{true}}>
+      {{#each this.facets as |facet|}}
+        <div
+          class="fx-row fx-malign-space-between fx-xalign-center padding-xxx-sm"
+          role="button"
+          {{on "click" (fn this.toggleFacet facet)}}
+        >
+          <div class="fx-row item">
+            {{#if this.ongoingFacetApply}}
+              <span class="margin-right-px-12">
+                <OSS::Icon @icon="fa-spinner-third fa-spin" />
+              </span>
+            {{else}}
+              <OSS::Checkbox
+                @checked={{array-includes this.appliedFacets facet.identifier}}
+                @size="sm"
+                @onChange={{fn this.toggleFacet facet}}
+                class="margin-right-px-12"
+              />
+            {{/if}}
+            {{yield (hash appliedFacets=this.appliedFacets facet=facet) to="facet-item"}}
+          </div>
+          <div class="count">
+            {{facet.count}}
+          </div>
         </div>
-
-        <div class="count">
-          {{facet.count}}
-        </div>
-      </div>
-    {{else}}
-      {{#if (has-block "empty-state")}}
-        {{yield to="empty-state"}}
       {{else}}
-        <div class="fx-col fx-1 fx-malign-center upf-align--center">
-          <p class="text-color-default">{{t "hypertable.column.facetting.empty_state.tagline"}}</p>
-          <p class="text-color-default-light">{{t "hypertable.column.facetting.empty_state.tagline_1"}}</p>
-        </div>
-      {{/if}}
-    {{/each}}
+        {{#if (has-block "empty-state")}}
+          {{yield to="empty-state"}}
+        {{else}}
+          <div class="fx-col fx-1 fx-malign-center upf-align--center">
+            <p class="text-color-default">{{t "hypertable.column.facetting.empty_state.tagline"}}</p>
+            <p class="text-color-default-light">{{t "hypertable.column.facetting.empty_state.tagline_1"}}</p>
+          </div>
+        {{/if}}
+      {{/each}}
+    </OSS::ScrollablePanel>
   {{/if}}
 </div>

--- a/app/styles/facetting.less
+++ b/app/styles/facetting.less
@@ -1,7 +1,6 @@
 .hypertable__facetting {
   height: 200px;
   overflow-y: auto;
-  padding-right: 10px;
 }
 
 .hypertable__facetting--loading {


### PR DESCRIPTION
### What does this PR do?

Related to : #[DRA-2093](https://linear.app/upfluence/issue/DRA-2093/white-gradient-at-the-top-and-bottom-of-the-section-status-filter-when)

### What are the observable changes?
![Screenshot from 2025-01-27 17-53-04](https://github.com/user-attachments/assets/cb85d638-4faf-4097-8b5c-ed4d5d9561ae)


### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
