### PR TITLE
In ManageColumns, fix needed double-click when the user typed a keyword

### DIFF
--- a/addon/components/hyper-table-v2/manage-columns.hbs
+++ b/addon/components/hyper-table-v2/manage-columns.hbs
@@ -29,13 +29,19 @@
     </div>
     <div class="available-fields-wrapper__fields">
       <div class="search">
-        <Input
-          @type="text"
-          @value={{this._searchColumnDefinitionKeyword}}
-          data-control-name="column_definitions_search_input"
-          class="upf-input"
-          placeholder={{t "hypertable.features.manage_fields.search_placeholder"}}
-        />
+        <OSS::InputContainer>
+          <:prefix>
+            <OSS::Icon @icon="fa-search" />
+          </:prefix>
+
+          <:input>
+            <Input
+              @value={{this._searchColumnDefinitionKeyword}}
+              placeholder={{t "hypertable.features.manage_fields.search_placeholder"}}
+              data-control-name="column_definitions_search_input"
+            />
+          </:input>
+        </OSS::InputContainer>
       </div>
       <div class="fields-list">
         {{#each-in this._orderedFilteredClusters as |clusterName fields|}}

--- a/addon/components/hyper-table-v2/manage-columns.hbs
+++ b/addon/components/hyper-table-v2/manage-columns.hbs
@@ -45,7 +45,12 @@
             </div>
           {{/if}}
           {{#each fields as |field|}}
-            <div class="field" role="button" {{on "click" (fn this.columnVisibilityUpdate field)}}>
+            <div
+              class="field"
+              role="button"
+              {{on "mousedown" this.noop}}
+              {{on "click" (fn this.columnVisibilityUpdate field)}}
+            >
               {{#if field.isLoading}}
                 <div><OSS::Icon @icon="fa-spinner fa-spin" /></div>
               {{else}}

--- a/addon/components/hyper-table-v2/manage-columns.ts
+++ b/addon/components/hyper-table-v2/manage-columns.ts
@@ -73,6 +73,10 @@ export default class HyperTableV2ManageColumns extends Component<HyperTableV2Man
     return new Map([...map].sort((a, b) => a[0].localeCompare(b[0])));
   }
 
+  noop(event: Event) {
+    event.preventDefault();
+  }
+
   @action
   columnVisibilityUpdate(column: ManagedColumn, event: PointerEvent): void {
     set(column, 'isLoading', true);


### PR DESCRIPTION
### What does this PR do?

- Prevent race condition between search input's blur event & columns toggling click event
- Add prefix search icon for consistency

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
