### PR TITLE
Improved: increased dropdown height for filtering in V2

### DIFF
--- a/app/styles/facetting.less
+++ b/app/styles/facetting.less
@@ -1,5 +1,5 @@
 .hypertable__facetting {
-  height: 200px;
+  height: 285px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
### What does this PR do?

Related to : #[DRA-2183](https://linear.app/upfluence/issue/DRA-2183/increase-dropdown-height-for-filtering-in-hyper-table-v2)

During the analysis, and seen with Max and William, the necessary height for hypertable__facetting was 270px so the dropdown would reach the desired 352px height.
For whatever reason, during implementation I had to up this number to 285px to reach the 352px goal.
No idea why this is happening, so screenshot added for proof :woman_shrugging: 

### What are the observable changes?
![Screenshot from 2025-02-06 11-41-25](https://github.com/user-attachments/assets/6f5bb6d5-7549-43dd-bea6-1f2ebaa246ff)


### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
