### PR TITLE
Hypertable v2: Single row loading state

### DIFF
--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -109,7 +109,7 @@
                       @row={{row}}
                       @onClick={{fn this.toggleRowSelection row}}
                       @onHover={{this.onRowHover}}
-                      @loading={{row.isLoading}}
+                      @loading={{row._isLoading}}
                     >
                       <OSS::Checkbox
                         @checked={{if
@@ -139,7 +139,7 @@
                     @row={{row}}
                     @onClick={{this.onRowClick}}
                     @onHover={{this.onRowHover}}
-                    @loading={{row.isLoading}}
+                    @loading={{row._isLoading}}
                   />
                 {{/each}}
 
@@ -175,7 +175,7 @@
                   @row={{row}}
                   @onClick={{this.onRowClick}}
                   @onHover={{this.onRowHover}}
-                  @loading={{row.isLoading}}
+                  @loading={{row._isLoading}}
                 />
               {{/each}}
 

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -109,6 +109,7 @@
                       @row={{row}}
                       @onClick={{fn this.toggleRowSelection row}}
                       @onHover={{this.onRowHover}}
+                      @loading={{row.isLoading}}
                     >
                       <OSS::Checkbox
                         @checked={{if
@@ -138,6 +139,7 @@
                     @row={{row}}
                     @onClick={{this.onRowClick}}
                     @onHover={{this.onRowHover}}
+                    @loading={{row.isLoading}}
                   />
                 {{/each}}
 
@@ -173,6 +175,7 @@
                   @row={{row}}
                   @onClick={{this.onRowClick}}
                   @onHover={{this.onRowHover}}
+                  @loading={{row.isLoading}}
                 />
               {{/each}}
 

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -128,6 +128,13 @@ export default class TableHandler {
     });
   }
 
+  async toggleRowLoadingState(recordId: number): Promise<void | boolean> {
+    return this.mutateRow(recordId, (row) => {
+      set(row, 'isLoading', !row.isLoading);
+      return true;
+    });
+  }
+
   reorderColumns(columns: Column[]) {
     this.columns = columns;
     this.tableManager.upsertColumns({ columns: this.columns });

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -128,9 +128,9 @@ export default class TableHandler {
     });
   }
 
-  async toggleRowLoadingState(recordId: number): Promise<void | boolean> {
+  async toggleRowLoadingState(recordId: number): Promise<boolean> {
     return this.mutateRow(recordId, (row) => {
-      set(row, 'isLoading', !row.isLoading);
+      set(row, '_isLoading', !row._isLoading);
       return true;
     });
   }

--- a/addon/core/interfaces/rows-fetcher.ts
+++ b/addon/core/interfaces/rows-fetcher.ts
@@ -3,6 +3,7 @@ export type Row = {
   recordId: number;
   holderId: number;
   holderType: string;
+  isLoading?: boolean;
   [key: string]: any;
 };
 

--- a/addon/core/interfaces/rows-fetcher.ts
+++ b/addon/core/interfaces/rows-fetcher.ts
@@ -3,7 +3,6 @@ export type Row = {
   recordId: number;
   holderId: number;
   holderType: string;
-  isLoading?: boolean;
   [key: string]: any;
 };
 

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -445,6 +445,26 @@ module('Unit | core/handler', function (hooks) {
     });
   });
 
+  module('Handler#toggleRowLoadingState', function () {
+    test('it skips if the record_id is not loaded yet', async function (this: TestContext, assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      await handler.fetchRows();
+
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+      await handler.toggleRowLoadingState(667);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+    });
+
+    test('it calls the toggleRowLoadingState method of the manager correctly', async function (this: TestContext, assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+      await handler.fetchRows();
+
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+      await handler.toggleRowLoadingState(12);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, true);
+    });
+  });
+
   module('Events', function () {
     test('callbacks are called properly when an event is subscribed to', function (this: TestContext, assert: Assert) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -450,18 +450,18 @@ module('Unit | core/handler', function (hooks) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
       await handler.fetchRows();
 
-      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!._isLoading, undefined);
       await handler.toggleRowLoadingState(667);
-      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!._isLoading, undefined);
     });
 
-    test('it calls the toggleRowLoadingState method of the manager correctly', async function (this: TestContext, assert: Assert) {
+    test("calling the method properly updates the row's loading state", async function (this: TestContext, assert: Assert) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
       await handler.fetchRows();
 
-      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, undefined);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!._isLoading, undefined);
       await handler.toggleRowLoadingState(12);
-      assert.equal(handler.rows.find((r) => r.record_id === 12)!.isLoading, true);
+      assert.equal(handler.rows.find((r) => r.record_id === 12)!._isLoading, true);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to : #[DRA-2421](https://linear.app/upfluence/issue/DRA-2421/shipping-address-reverts-to-facade-one-after-shortlisting-creator-in)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
Usage example 

https://github.com/user-attachments/assets/6eb2cf63-3c16-4850-b85f-add1f0e24d3c


⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
