### PR TITLE
Hypertable v2: use the header's column as draggable handle

### DIFF
--- a/addon/components/hyper-table-v2/column.hbs
+++ b/addon/components/hyper-table-v2/column.hbs
@@ -20,8 +20,6 @@
       </div>
     </div>
 
-    <OSS::Icon @icon="fa-bars fa-rotate-90" />
-
     <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" @column.definition.key}}>
       {{#if (or @column.definition.filterable @column.definition.orderable)}}
         <OSS::Icon

--- a/addon/components/hyper-table-v2/column.hbs
+++ b/addon/components/hyper-table-v2/column.hbs
@@ -20,30 +20,32 @@
       </div>
     </div>
 
-    <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" @column.definition.key}}>
-      {{#if (or @column.definition.filterable @column.definition.orderable)}}
-        <OSS::Icon
-          @icon="fa-filter"
-          role="button"
-          {{on "click" this.toggleFilteringComponent}}
-          {{enable-tooltip title=(t "hypertable.column.filtering.label")}}
-        />
-      {{/if}}
+    <OSS::Icon @icon="fa-bars fa-rotate-90" {{sortable-handle}} />
 
-      {{#if (and this.filteringComponent (eq @handler.tetherOn @column.definition.key))}}
-        <div class="available-filters" {{on-click-outside this.toggleFilteringComponent}}>
-          <this.filteringComponent.component
-            @handler={{@handler}}
-            @column={{@column}}
-            @extra={{this.filteringComponent.args}}
-          />
-        </div>
-      {{/if}}
+    {{!-- <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" @column.definition.key}}> --}}
+    {{!-- {{#if (or @column.definition.filterable @column.definition.orderable)}} --}}
+    {{! <OSS::Icon }}
+    {{! @icon="fa-filter" }}
+    {{! role="button" }}
+    {{!-- {{on "click" this.toggleFilteringComponent}} --}}
+    {{!-- {{enable-tooltip title=(t "hypertable.column.filtering.label")}} --}}
+    {{! /> }}
+    {{!-- {{/if}} --}}
 
-      {{#if this.displayMoveIndicator}}
-        <OSS::Icon @icon="fa-bars fa-rotate-90" />
-      {{/if}}
-    </div>
+    {{!-- {{#if (and this.filteringComponent (eq @handler.tetherOn @column.definition.key))}} --}}
+    {{!-- <div class="available-filters" {{on-click-outside this.toggleFilteringComponent}}> --}}
+    {{! <this.filteringComponent.component }}
+    {{!-- @handler={{@handler}} --}}
+    {{!-- @column={{@column}} --}}
+    {{!-- @extra={{this.filteringComponent.args}} --}}
+    {{! /> }}
+    {{! </div> }}
+    {{!-- {{/if}} --}}
+
+    {{!-- {{#if this.displayMoveIndicator}} --}}
+    {{! <OSS::Icon @icon="fa-bars fa-rotate-90" /> }}
+    {{!-- {{/if}} --}}
+    {{! </div> }}
   </header>
 
   {{yield}}

--- a/addon/components/hyper-table-v2/column.hbs
+++ b/addon/components/hyper-table-v2/column.hbs
@@ -1,5 +1,5 @@
 <div id={{this.elementId}} class={{this.computedClasses}} ...attributes>
-  <header class="fx-row fx-malign-space-between">
+  <header class="fx-row fx-malign-space-between" {{sortable-handle}}>
     <div class="cell-header" role="button" {{on "click" this.orderColumn}}>
       <div class="header-title-container">
         {{#if this.loadingHeaderComponent}}
@@ -20,32 +20,32 @@
       </div>
     </div>
 
-    <OSS::Icon @icon="fa-bars fa-rotate-90" {{sortable-handle}} />
+    <OSS::Icon @icon="fa-bars fa-rotate-90" />
 
-    {{!-- <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" @column.definition.key}}> --}}
-    {{!-- {{#if (or @column.definition.filterable @column.definition.orderable)}} --}}
-    {{! <OSS::Icon }}
-    {{! @icon="fa-filter" }}
-    {{! role="button" }}
-    {{!-- {{on "click" this.toggleFilteringComponent}} --}}
-    {{!-- {{enable-tooltip title=(t "hypertable.column.filtering.label")}} --}}
-    {{! /> }}
-    {{!-- {{/if}} --}}
+    <div class="icon-commands" data-control-name={{concat "table_column_filter_sort_toggle_" @column.definition.key}}>
+      {{#if (or @column.definition.filterable @column.definition.orderable)}}
+        <OSS::Icon
+          @icon="fa-filter"
+          role="button"
+          {{on "click" this.toggleFilteringComponent}}
+          {{enable-tooltip title=(t "hypertable.column.filtering.label")}}
+        />
+      {{/if}}
 
-    {{!-- {{#if (and this.filteringComponent (eq @handler.tetherOn @column.definition.key))}} --}}
-    {{!-- <div class="available-filters" {{on-click-outside this.toggleFilteringComponent}}> --}}
-    {{! <this.filteringComponent.component }}
-    {{!-- @handler={{@handler}} --}}
-    {{!-- @column={{@column}} --}}
-    {{!-- @extra={{this.filteringComponent.args}} --}}
-    {{! /> }}
-    {{! </div> }}
-    {{!-- {{/if}} --}}
+      {{#if (and this.filteringComponent (eq @handler.tetherOn @column.definition.key))}}
+        <div class="available-filters" {{on-click-outside this.toggleFilteringComponent}}>
+          <this.filteringComponent.component
+            @handler={{@handler}}
+            @column={{@column}}
+            @extra={{this.filteringComponent.args}}
+          />
+        </div>
+      {{/if}}
 
-    {{!-- {{#if this.displayMoveIndicator}} --}}
-    {{! <OSS::Icon @icon="fa-bars fa-rotate-90" /> }}
-    {{!-- {{/if}} --}}
-    {{! </div> }}
+      {{#if this.displayMoveIndicator}}
+        <OSS::Icon @icon="fa-bars fa-rotate-90" />
+      {{/if}}
+    </div>
   </header>
 
   {{yield}}


### PR DESCRIPTION
### What does this PR do?

Currently, when a column is draggable, it's whole content can be used as handle (including the rows' cells), leading to weird behaviours.

This PR ensures users can only drag a column by its header using ember-sortable's `sortable-handle` modifier.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
