### PR TITLE
Fixed V2 From-To filter arrow use

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/numeric.hbs
@@ -30,7 +30,7 @@
               placeholder={{t "hypertable.column.filtering.from"}}
               aria-label={{t "hypertable.column.filtering.from"}}
               autocomplete="off"
-              {{on "keydown" this.addRangeFilter}}
+              {{on "change" this.addRangeFilter}}
               {{did-insert this.setupOnlyNumericListener}}
               {{will-destroy this.teardownOnlyNumericListener}}
               data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_range_from"}}
@@ -47,7 +47,7 @@
               @value={{this.upperBoundFilter}}
               placeholder={{t "hypertable.column.filtering.to"}}
               autocomplete="off"
-              {{on "keydown" this.addRangeFilter}}
+              {{on "change" this.addRangeFilter}}
               {{did-insert this.setupOnlyNumericListener}}
               {{will-destroy this.teardownOnlyNumericListener}}
               data-control-name={{concat "hypertable__column_filtering_for_" @column.definition.key "_range_to"}}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to : #[DRA-2234](https://linear.app/upfluence/issue/DRA-2234/hyper-table-v2-from-to-filter-doesnt-work-when-values-are-set-using)

### What are the observable changes?

From-To filter now reacts to value change when clicking on the arrows
https://www.loom.com/share/b5c9a6b4ec724bfbaf7cb5bbd6666bbb

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
