### PR TITLE
Properly reset the handler instance props when the table is unmounted

### DIFF
--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -1,4 +1,4 @@
-<div class="hypertable-container" ...attributes>
+<div class="hypertable-container" {{will-destroy this.teardown}} ...attributes>
   <div class="hypertable__upper-header">
     <div class="fx-row">
       <div class="left-side">

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -154,6 +154,11 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     window.location.reload();
   }
 
+  @action
+  teardown(): void {
+    this.args.handler.teardown();
+  }
+
   get columnsCountStyle(): ReturnType<typeof htmlSafe> {
     return htmlSafe(`--hypertable-responsive-columns-number: ${this.args.handler.columns.length - 1}`);
   }

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -460,6 +460,10 @@ export default class TableHandler {
     }
   }
 
+  teardown(): void {
+    this.currentPage = 1;
+  }
+
   private _reinitColumnsAndRows(columns: Column[]): void {
     let shouldRedraw = false;
     columns.forEach((column) => {

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -10,6 +10,7 @@ import { buildColumn } from '@upfluence/hypertable/test-support/table-manager';
 
 module('Integration | Component | hyper-table-v2', function (hooks) {
   setupRenderingTest(hooks);
+
   hooks.beforeEach(function (this: TestContext) {
     this.tableManager = new TableManager();
     this.rowsFetcher = new RowsFetcher();
@@ -77,6 +78,18 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
 
     // @ts-ignore
     assert.ok(handlerSpy.triggerEvent.calledOnceWithExactly('row-click', this.handler.rows[0]));
+  });
+
+  test('when destroyed, the table properly calls the handler teardown method', async function (this: TestContext, assert: Assert) {
+    this.displayTable = true;
+
+    const teardownStub = sinon.stub(this.handler, 'teardown');
+
+    await render(hbs`{{#if this.displayTable}}<HyperTableV2 @handler={{this.handler}} />{{/if}}`);
+
+    this.set('displayTable', false);
+
+    assert.ok(teardownStub.calledOnce);
   });
 
   module('empty state', function (hooks) {

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -82,13 +82,11 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
 
   test('when destroyed, the table properly calls the handler teardown method', async function (this: TestContext, assert: Assert) {
     this.displayTable = true;
-
     const teardownStub = sinon.stub(this.handler, 'teardown');
 
     await render(hbs`{{#if this.displayTable}}<HyperTableV2 @handler={{this.handler}} />{{/if}}`);
 
     this.set('displayTable', false);
-
     assert.ok(teardownStub.calledOnce);
   });
 

--- a/tests/unit/core/handler-test.ts
+++ b/tests/unit/core/handler-test.ts
@@ -465,6 +465,19 @@ module('Unit | core/handler', function (hooks) {
     });
   });
 
+  module('Handler#teardown', function () {
+    test('the currentPage is properly reset', function (this: TestContext, assert: Assert) {
+      const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);
+
+      handler.currentPage = 2;
+      assert.equal(handler.currentPage, 2);
+
+      handler.teardown();
+
+      assert.equal(handler.currentPage, 1);
+    });
+  });
+
   module('Events', function () {
     test('callbacks are called properly when an event is subscribed to', function (this: TestContext, assert: Assert) {
       const handler = new TableHandler(getContext(), this.tableManager, this.rowsFetcher);


### PR DESCRIPTION
### What does this PR do?

Properly reset the handler instance props when the table is unmounted

### What are the observable changes?

Fixes an issue where when leaving a page that was displaying a table, the currentPage wouldn't be reset and the user would resume from the last page loaded.

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
