### PR TITLE
Hypertable v2: Reset selection when rows are all excluded

### DIFF
--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -125,6 +125,7 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
   toggleRowSelection(row: Row): void {
     if (this.args.handler.selection === 'all') {
       this.args.handler.updateExclusion(row);
+      this.resetSelectionOnFullExclusion();
     } else {
       this.args.handler.updateSelection(row);
     }
@@ -185,5 +186,11 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     });
 
     this.computeScrollableTable();
+  }
+
+  private resetSelectionOnFullExclusion(): void {
+    if ((this.args.handler.rowsMeta?.total ?? 0) === this.args.handler.exclusion.length) {
+      this.args.handler.clearSelection();
+    }
   }
 }

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -357,6 +357,26 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
           }
         );
       });
+
+      test('When all rows are excluded, it resets the selection', async function (this: any, assert: Assert) {
+        await render(hbs`<HyperTableV2 @handler={{this.handler}} @features={{hash selection=true}} />`);
+        this.handler.rowsMeta.total = 3;
+        await click('.hypertable__column.hypertable__column--selection header .upf-checkbox');
+        assert.deepEqual(this.handler.selection, 'all');
+
+        await click('.hypertable__column.hypertable__column--selection .hypertable__cell:nth-of-type(1) .upf-checkbox');
+        assert.deepEqual(this.handler.selection, 'all');
+        assert.deepEqual(this.handler.exclusion.length, 1);
+
+        await click('.hypertable__column.hypertable__column--selection .hypertable__cell:nth-of-type(2) .upf-checkbox');
+        assert.deepEqual(this.handler.selection, 'all');
+        assert.deepEqual(this.handler.exclusion.length, 2);
+
+        await click('.hypertable__column.hypertable__column--selection .hypertable__cell:nth-of-type(3) .upf-checkbox');
+
+        assert.deepEqual(this.handler.selection, []);
+        assert.deepEqual(this.handler.exclusion, []);
+      });
     });
 
     test('clicking a one multiline checkbox toggles its selection status', async function (this: TestContext, assert: Assert) {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to : #[DRA-3012](https://linear.app/upfluence/issue/DRA-3012/display-contact-all-to-better-promote-outreach-plan)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
The goal is to remove this issue where selection remains to `all` even if all rows are excluded 🙏 

https://github.com/user-attachments/assets/aa085e54-1690-465a-b035-c86207f384ef


<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
