### PR TITLE
Updated facets loader to include radio button exclusive option

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
@@ -32,7 +32,10 @@
               </span>
             {{else}}
               {{#if @exclusive}}
-                <OSS::RadioButton @selected={{array-includes this.appliedFacets facet.identifier}} class="margin-right-px-12"/>
+                <OSS::RadioButton
+                  @selected={{array-includes this.appliedFacets facet.identifier}}
+                  class="margin-right-px-12"
+                />
               {{else}}
                 <OSS::Checkbox
                   @checked={{array-includes this.appliedFacets facet.identifier}}

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.hbs
@@ -31,12 +31,16 @@
                 <OSS::Icon @icon="fa-spinner-third fa-spin" />
               </span>
             {{else}}
-              <OSS::Checkbox
-                @checked={{array-includes this.appliedFacets facet.identifier}}
-                @size="sm"
-                @onChange={{fn this.toggleFacet facet}}
-                class="margin-right-px-12"
-              />
+              {{#if @exclusive}}
+                <OSS::RadioButton @selected={{array-includes this.appliedFacets facet.identifier}} class="margin-right-px-12"/>
+              {{else}}
+                <OSS::Checkbox
+                  @checked={{array-includes this.appliedFacets facet.identifier}}
+                  @size="sm"
+                  @onChange={{fn this.toggleFacet facet}}
+                  class="margin-right-px-12"
+                />
+              {{/if}}
             {{/if}}
             {{yield (hash appliedFacets=this.appliedFacets facet=facet) to="facet-item"}}
           </div>

--- a/tests/integration/components/hyper-table/cell-renderers/image-test.js
+++ b/tests/integration/components/hyper-table/cell-renderers/image-test.js
@@ -7,8 +7,8 @@ module('Integration | Component | hyper-table/cell-renderers/image', function (h
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    this.item = { imageURL: 'foo.png' };
-    this.column = { key: 'imageURL' };
+    this.item = { imageURL: 'foo.png', name: 'FooBar' };
+    this.column = { key: 'imageURL', labels: ['name'] };
 
     await render(hbs`<HyperTable::CellRenderers::Image @item={{this.item}} @column={{this.column}} />`);
 


### PR DESCRIPTION
### What does this PR do?
<img width="399" height="524" alt="Screenshot from 2025-09-11 17-56-07" src="https://github.com/user-attachments/assets/f6d67142-ba38-46f8-afea-20ce36f64549" />

Related to : #[dra-3650](https://linear.app/upfluence/issue/DRA-3650/hypertable-extension-groundwork-create-new-instagramstoriesaccess)

### What are the observable changes?
<img width="399" height="524" alt="Screenshot from 2025-09-11 17-56-07" src="https://github.com/user-attachments/assets/f6d67142-ba38-46f8-afea-20ce36f64549" />

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
