### PR TITLE
Facets: Fix concurenccy issues when user toggle facets fast

### DIFF
--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -81,6 +81,7 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
     debounce(
       this,
       () => {
+        this.ongoingFacetApply = true;
         this.appliedFacets.includes(facet.identifier) ? this.removeFacet(facet) : this.addFacet(facet);
       },
       facet,
@@ -96,7 +97,6 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
       facetFilter = { key: this.filteringKey, value: [existingFilter.value, facet.identifier].join(',') };
     }
 
-    this.ongoingFacetApply = true;
     this.args.handler
       .applyFilters(this.args.column, [facetFilter])
       .then(() => {
@@ -120,7 +120,6 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
         facetFilter = { key: this.filteringKey, value: '' };
       }
 
-      this.ongoingFacetApply = true;
       return this.args.handler
         .applyFilters(this.args.column, [facetFilter])
         .then(() => {

--- a/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
+++ b/addon/components/hyper-table-v2/filtering-renderers/common/facets-loader.ts
@@ -22,7 +22,6 @@ interface FacetsLoaderArgs {
 }
 
 const SEARCH_DEBOUNCE_TIME: number = 300;
-const FACET_APPLY_DEBOUNCE_TIME: number = 300;
 
 export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs> {
   @service declare intl: IntlService;
@@ -78,15 +77,9 @@ export default class HyperTableV2FacetsLoader extends Component<FacetsLoaderArgs
   @action
   toggleFacet(facet: Facet): void {
     if (this.ongoingFacetApply) return;
-    debounce(
-      this,
-      () => {
-        this.ongoingFacetApply = true;
-        this.appliedFacets.includes(facet.identifier) ? this.removeFacet(facet) : this.addFacet(facet);
-      },
-      facet,
-      FACET_APPLY_DEBOUNCE_TIME
-    );
+
+    this.ongoingFacetApply = true;
+    this.appliedFacets.includes(facet.identifier) ? this.removeFacet(facet) : this.addFacet(facet);
   }
 
   private addFacet(facet: Facet): void {

--- a/addon/core/handler.ts
+++ b/addon/core/handler.ts
@@ -286,8 +286,9 @@ export default class TableHandler {
     );
 
     return this.tableManager.upsertColumns({ columns: this.columns }).then(({ columns }) => {
-      this._reinitColumnsAndRows(columns);
-      this.triggerEvent('apply-filters', column, filters);
+      return this._reinitColumnsAndRows(columns).then(() => {
+        this.triggerEvent('apply-filters', column, filters);
+      });
     });
   }
 
@@ -477,7 +478,7 @@ export default class TableHandler {
     this.currentPage = 1;
   }
 
-  private _reinitColumnsAndRows(columns: Column[]): void {
+  private _reinitColumnsAndRows(columns: Column[]): Promise<void> {
     let shouldRedraw = false;
     columns.forEach((column) => {
       let existingColumn = this.columns.find((c) => c.definition.key === column.definition.key);
@@ -493,6 +494,6 @@ export default class TableHandler {
 
     this.rows = [];
     this.currentPage = 1;
-    this.fetchRows();
+    return this.fetchRows();
   }
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to : #[DRA-4855](https://linear.app/upfluence/issue/DRA-4855/campaign-status-filter-not-giving-the-right-results-litanika-home)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

When user select/unselect multiple facets, X requests are send to the backend, the first request send is not always the first received which results on discrepencies between expected & displayed data. 

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
