### PR TITLE
Fix sticky column logic and ColumnDefinition type

### DIFF
--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -49,7 +49,7 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
     this.elementId = guidFor(args.column.definition.key);
   }
 
-  @computed('args.column.filters.[]', 'args.column.order.direction', 'sizeClass')
+  @computed('args.column.filters.[]', 'args.column.order.direction', 'sizeClass', 'stickyColumnClass')
   get computedClasses(): string {
     const classes = ['hypertable__column'];
 
@@ -61,6 +61,10 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
 
     if (this.args.column.filters.length > 0) {
       classes.push('hypertable__column--filtered');
+    }
+
+    if (this.stickyColumnClass) {
+      classes.push(this.stickyColumnClass);
     }
 
     return classes.join(' ');
@@ -79,6 +83,15 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
   @computed('args.column.order.direction')
   get isOrderingIndicatorVisible(): boolean {
     return this.args.column.definition.orderable && !this.args.column.order?.direction;
+  }
+
+  @computed('args.column.definition.position')
+  get stickyColumnClass(): string | undefined {
+    const position = this.args.column.definition?.position;
+
+    if (!position?.sticky) return undefined;
+
+    return `hypertable__column--sticky-${position.side ?? 'left'}`;
   }
 
   @action

--- a/addon/components/hyper-table-v2/column.ts
+++ b/addon/components/hyper-table-v2/column.ts
@@ -49,7 +49,7 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
     this.elementId = guidFor(args.column.definition.key);
   }
 
-  @computed('args.column.filters.[]', 'args.column.order.direction', 'sizeClass', 'stickyColumnClass')
+  @computed('args.column.filters.[]', 'args.column.order.direction', 'sizeClass')
   get computedClasses(): string {
     const classes = ['hypertable__column'];
 
@@ -85,7 +85,6 @@ export default class HyperTableV2Column extends Component<HyperTableV2ColumnArgs
     return this.args.column.definition.orderable && !this.args.column.order?.direction;
   }
 
-  @computed('args.column.definition.position')
   get stickyColumnClass(): string | undefined {
     const position = this.args.column.definition?.position;
 

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -167,7 +167,6 @@
               @handler={{@handler}}
               @column={{column}}
               @delegatedFiltering={{@options.delegatedFiltering}}
-              class={{fn this.getStickyColumnClass column}}
               {{sortable-item
                 groupName=this.hypertableInstanceID
                 model=column

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -167,10 +167,7 @@
               @handler={{@handler}}
               @column={{column}}
               @delegatedFiltering={{@options.delegatedFiltering}}
-              class={{if
-                column.definition.position.sticky
-                (concat "hypertable__column--sticky-" column.definition.position.side)
-              }}
+              class={{this.getStickyColumnClass column}}
               {{sortable-item
                 groupName=this.hypertableInstanceID
                 model=column

--- a/addon/components/hyper-table-v2/index.hbs
+++ b/addon/components/hyper-table-v2/index.hbs
@@ -167,7 +167,7 @@
               @handler={{@handler}}
               @column={{column}}
               @delegatedFiltering={{@options.delegatedFiltering}}
-              class={{this.getStickyColumnClass column}}
+              class={{fn this.getStickyColumnClass column}}
               {{sortable-item
                 groupName=this.hypertableInstanceID
                 model=column

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -182,14 +182,6 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     return htmlSafe(`--hypertable-responsive-columns-number: ${this.args.handler.columns.length - 1}`);
   }
 
-  getStickyColumnClass(column: Column): string | undefined {
-    const position = column.definition?.position;
-
-    if (!position?.sticky) return;
-
-    return `hypertable__column--sticky-${position.side ?? 'left'}`;
-  }
-
   private _resetFilters(): void {
     this.loadingResetFilters = true;
     this.args.handler.resetColumns(this.args.handler.columns).finally(() => {

--- a/addon/components/hyper-table-v2/index.ts
+++ b/addon/components/hyper-table-v2/index.ts
@@ -182,6 +182,14 @@ export default class HyperTableV2 extends Component<HyperTableV2Args> {
     return htmlSafe(`--hypertable-responsive-columns-number: ${this.args.handler.columns.length - 1}`);
   }
 
+  getStickyColumnClass(column: Column): string | undefined {
+    const position = column.definition?.position;
+
+    if (!position?.sticky) return;
+
+    return `hypertable__column--sticky-${position.side ?? 'left'}`;
+  }
+
   private _resetFilters(): void {
     this.loadingResetFilters = true;
     this.args.handler.resetColumns(this.args.handler.columns).finally(() => {

--- a/addon/core/interfaces/column.ts
+++ b/addon/core/interfaces/column.ts
@@ -20,9 +20,14 @@ export type ColumnDefinition = {
   facetable: boolean;
   facetable_by: string[] | null;
   empty_state_message?: string;
-  position?: {
-    sticky: boolean;
-  };
+  position?:
+    | {
+        sticky: false;
+      }
+    | {
+        sticky: true;
+        side?: 'left' | 'right';
+      };
 };
 
 export type Filter = {

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -679,5 +679,17 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
 
       assert.dom('.hypertable__column--sticky-right').exists();
     });
+
+    test('Sticky attribute provided with left side - column renders with sticky-left class', async function (this: TestContext, assert: Assert) {
+      sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
+        return Promise.resolve({
+          columns: [buildColumn('foo'), buildColumn('bar', { position: { sticky: true, side: 'left' } })]
+        });
+      });
+
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
+
+      assert.dom('.hypertable__column--sticky-left').exists();
+    });
   });
 });

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -643,7 +643,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
   }
 
   module('sticky column class', function () {
-    test('no sticky - column renders without sticky class', async function (this: TestContext, assert: Assert) {
+    test('Sticky attribute not provided - column renders without sticky class', async function (this: TestContext, assert: Assert) {
       sinon.stub(this.tableManager, 'fetchColumns').callsFake(() =>
         Promise.resolve({
           columns: [buildColumn('foo', { position: undefined }), buildColumn('bar', { position: undefined })]
@@ -656,7 +656,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('.hypertable__column--sticky-right').doesNotExist();
     });
 
-    test('sticky with no side - column renders with sticky-left class', async function (this: TestContext, assert: Assert) {
+    test('Sticky attribute provided with no side - column renders with sticky-left class', async function (this: TestContext, assert: Assert) {
       sinon.stub(this.tableManager, 'fetchColumns').callsFake(() =>
         Promise.resolve({
           columns: [buildColumn('foo'), buildColumn('bar', { position: { sticky: true } })]
@@ -668,7 +668,7 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
       assert.dom('.hypertable__column--sticky-left').exists();
     });
 
-    test('sticky with right side - column renders with sticky-right class', async function (this: TestContext, assert: Assert) {
+    test('Sticky attribute provided with right side - column renders with sticky-right class', async function (this: TestContext, assert: Assert) {
       sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
         return Promise.resolve({
           columns: [buildColumn('foo'), buildColumn('bar', { position: { sticky: true, side: 'right' } })]

--- a/tests/integration/components/hyper-table-v2-test.ts
+++ b/tests/integration/components/hyper-table-v2-test.ts
@@ -641,4 +641,43 @@ module('Integration | Component | hyper-table-v2', function (hooks) {
         meta: { total: 12 }
       });
   }
+
+  module('sticky column class', function () {
+    test('no sticky - column renders without sticky class', async function (this: TestContext, assert: Assert) {
+      sinon.stub(this.tableManager, 'fetchColumns').callsFake(() =>
+        Promise.resolve({
+          columns: [buildColumn('foo', { position: undefined }), buildColumn('bar', { position: undefined })]
+        })
+      );
+
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
+
+      assert.dom('.hypertable__column--sticky-left').doesNotExist();
+      assert.dom('.hypertable__column--sticky-right').doesNotExist();
+    });
+
+    test('sticky with no side - column renders with sticky-left class', async function (this: TestContext, assert: Assert) {
+      sinon.stub(this.tableManager, 'fetchColumns').callsFake(() =>
+        Promise.resolve({
+          columns: [buildColumn('foo'), buildColumn('bar', { position: { sticky: true } })]
+        })
+      );
+
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
+
+      assert.dom('.hypertable__column--sticky-left').exists();
+    });
+
+    test('sticky with right side - column renders with sticky-right class', async function (this: TestContext, assert: Assert) {
+      sinon.stub(this.tableManager, 'fetchColumns').callsFake(() => {
+        return Promise.resolve({
+          columns: [buildColumn('foo'), buildColumn('bar', { position: { sticky: true, side: 'right' } })]
+        });
+      });
+
+      await render(hbs`<HyperTableV2 @handler={{this.handler}} />`);
+
+      assert.dom('.hypertable__column--sticky-right').exists();
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes sticky column class computation in HyperTable v2 and aligns `ColumnDefinition.position` typing with actual sticky behavior/side usage.

Related to : [#DRA-5002](https://linear.app/upfluence/issue/DRA-5002/oauth-settings-web-define-the-credentials-table-columns)

### What are the observable changes?

- Sticky column class is now computed in component logic preventing invalid class generation when position data is missing.
- Sticky side handling now supports both left and right (`hypertable__column--sticky-left` / `hypertable__column--sticky-right`), defaulting to left when sticky is enabled without an explicit side. ⚠️ **I took the assumption that the default sticky side is the left side (which seems to be the default behavior in the app) so as to not break the upfluence-web.**

- `ColumnDefinition.position` now uses a discriminated union:
  - `{ sticky: false }`
  - `{ sticky: true; side?: 'left' | 'right' }`
  This improves type safety and matches runtime behavior.

### 🧑‍💻 Developer Heads Up

- The API **should** not change. The behavior should not change

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

- I used [discriminated union](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions) typing for better DX.
- Bug fix & type correction.