### PR TITLE
Ensure error state has full width in hypertable

### DIFF
--- a/addon/components/hyper-table-v2/cell-renderers/text.hbs
+++ b/addon/components/hyper-table-v2/cell-renderers/text.hbs
@@ -1,5 +1,5 @@
 {{#if this.value}}
-  <span class="text-ellipsis" {{enable-tooltip title=this.value placement="top"}}>
+  <span class="text-ellipsis" {{enable-tooltip title=this.value placement="top" displayOnlyOnOverflow=true}}>
     {{this.value}}
   </span>
 {{else}}

--- a/app/styles/hypertable.less
+++ b/app/styles/hypertable.less
@@ -45,6 +45,7 @@
 
   &--error {
     background-color: var(--color-white);
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

While implementing the new table for oauth client credentials, we noticed that the error state of hypertable wasn't taking up the full width of the space. See picture below.

<img width="1175" height="535" alt="image" src="https://github.com/user-attachments/assets/33c1dee3-d358-446e-a9dd-2bdbe880e512" />


Related to : [#dra-5212](https://linear.app/upfluence/issue/DRA-5212/pre-qa-provide-oauth-client-credentials-authentication-for-api)

### What are the observable changes?

<img width="1173" height="531" alt="image" src="https://github.com/user-attachments/assets/ade7f0da-2532-4f21-a3a1-5f580dee0552" />


### 🧑‍💻 Developer Heads Up


### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

