### PR TITLE
[hypertable] Updated date format in cell renderer

### DIFF
--- a/addon/components/hyper-table-v2/cell-renderers/date.ts
+++ b/addon/components/hyper-table-v2/cell-renderers/date.ts
@@ -12,7 +12,7 @@ interface HyperTableV2RenderersDateArgs {
   extra?: { [key: string]: any };
 }
 
-const DEFAULT_DATE_FORMAT = 'MMM. DD, YYYY';
+const DEFAULT_DATE_FORMAT = 'MMM DD, YYYY';
 
 export default class HyperTableV2CellRenderersDate extends Component<HyperTableV2RenderersDateArgs> {
   get value() {

--- a/addon/components/hyper-table-v2/cell-renderers/date.ts
+++ b/addon/components/hyper-table-v2/cell-renderers/date.ts
@@ -12,7 +12,7 @@ interface HyperTableV2RenderersDateArgs {
   extra?: { [key: string]: any };
 }
 
-const DEFAULT_DATE_FORMAT = 'MMMM D, YYYY';
+const DEFAULT_DATE_FORMAT = 'MMM. DD, YYYY';
 
 export default class HyperTableV2CellRenderersDate extends Component<HyperTableV2RenderersDateArgs> {
   get value() {

--- a/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
@@ -29,7 +29,7 @@ module('Integration | Component | hyper-table-v2/cell-renderers/date', function 
 
     assert.equal(this.column.definition.key, 'date');
     assert.equal(this.row[this.column.definition.key], '1643386394');
-    assert.dom().hasText('Jan. 28, 2022');
+    assert.dom().hasText('Jan 28, 2022');
   });
 
   test('it renders a default - when the value is null', async function (this: TestContext, assert) {

--- a/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
+++ b/tests/integration/components/hyper-table-v2/cell-renderers/date-test.ts
@@ -29,7 +29,7 @@ module('Integration | Component | hyper-table-v2/cell-renderers/date', function 
 
     assert.equal(this.column.definition.key, 'date');
     assert.equal(this.row[this.column.definition.key], '1643386394');
-    assert.dom().hasText('January 28, 2022');
+    assert.dom().hasText('Jan. 28, 2022');
   });
 
   test('it renders a default - when the value is null', async function (this: TestContext, assert) {


### PR DESCRIPTION
### What does this PR do?

Changed date format in date cell renderer.

Related to : #[dra-2915](https://linear.app/upfluence/issue/DRA-2915/setting-to-change-date-format-in-the-software)

### What are the observable changes?

<img width="186" height="375" alt="Capture d’écran 2026-08-05 à 16 44 26" src="https://github.com/user-attachments/assets/4792f375-325c-487a-92f8-bea16bfd8ec5" />


### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:

- Feel free to migrate existing components to Glimmer Components.
- Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
